### PR TITLE
Remove decimal display of monster health on widget

### DIFF
--- a/HunterPie/GUI/Helpers/PercentageConverter.cs
+++ b/HunterPie/GUI/Helpers/PercentageConverter.cs
@@ -7,7 +7,7 @@ namespace HunterPie.GUI.Helpers {
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture) {
             double ProgressValue = System.Convert.ToDouble(values[0]);
             double ProgressMaximum = System.Convert.ToDouble(values[1]);
-            return String.Format("{0:0.00}/{1:0.00} ({2:0}%)", ProgressValue, ProgressMaximum, (ProgressValue / ProgressMaximum) * 100);
+            return String.Format("{0:0}/{1:0} ({2:0}%)", ProgressValue, ProgressMaximum, (ProgressValue / ProgressMaximum) * 100);
         }
 
         public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) {


### PR DESCRIPTION
I find the health bar values a bit difficult to read during combat.

I think not displaying the decimal bits of the health would solve the issue. I can't imagine many people being interested in the difference of less than one HP. The extra digits and punctuation add visual clutter that I think makes things harder to read.

Before change:
```
1000.76/2000.00 (50%)
```

After change:
```
1000/2000 (50%)
```

I haven't actually tested this (since I don't normally develop in C#), but I used an online C# string formatting tester to verify the change to the format string did what I think it should.


Please feel free to disregard this PR if it's not to your liking.

Thanks for your work on HunterPie! I enjoy it a lot. I quite enjoy just having the monster healthbars on the screen. The auto-updater is also pretty darn convenient.