### PR TITLE
Additional monster bar mode

### DIFF
--- a/HunterPie/Core/Monster/Monster.cs
+++ b/HunterPie/Core/Monster/Monster.cs
@@ -323,7 +323,7 @@ namespace HunterPie.Core {
             Int64 TargettedMonsterAddress = Scanner.READ_MULTILEVEL_PTR(Address.BASE + Address.MONSTER_SELECTED_OFFSET, Address.Offsets.MonsterSelectedOffsets);
             this.IsTarget = TargettedMonsterAddress == this.MonsterAddress;
 
-            Int64 selectedPtr = Scanner.READ_LONGLONG(Address.BASE + 0x4ECB740);
+            Int64 selectedPtr = Scanner.READ_LONGLONG(Address.BASE + 0x4ECB740); //probably want an offset for this
             bool isSelect = Scanner.READ_LONGLONG(selectedPtr + 0x128) != 0x0 && Scanner.READ_LONGLONG(selectedPtr + 0x130) != 0x0 && Scanner.READ_LONGLONG(selectedPtr + 0x160) != 0x0;
             //Int64 SelectedMonsterAddress = Scanner.READ_LONGLONG(selectedPtr + 0x148); // don't actually need this as it will be the same as TargettedMonsterAddress if isSelect is true
             if (!isSelect) {

--- a/HunterPie/Core/Monster/Monster.cs
+++ b/HunterPie/Core/Monster/Monster.cs
@@ -13,6 +13,7 @@ namespace HunterPie.Core {
         private float _currentHP;
         private float _Stamina;
         private bool _IsTarget;
+        private int _IsSelect; //0 = None, 1 = This, 2 = Other
         private float _enrageTimer = 0;
         private float _SizeMultiplier;
         
@@ -89,6 +90,16 @@ namespace HunterPie.Core {
             set {
                 if (value != _IsTarget) {
                     _IsTarget = value;
+                    _onTargetted();
+                }
+            }
+        }
+        public int IsSelect
+        {
+            get { return _IsSelect; }
+            set {
+                if (value != _IsSelect) {
+                    _IsSelect = value;
                     _onTargetted();
                 }
             }
@@ -311,6 +322,17 @@ namespace HunterPie.Core {
         private void GetTargetMonsterAddress() {
             Int64 TargettedMonsterAddress = Scanner.READ_MULTILEVEL_PTR(Address.BASE + Address.MONSTER_SELECTED_OFFSET, Address.Offsets.MonsterSelectedOffsets);
             this.IsTarget = TargettedMonsterAddress == this.MonsterAddress;
+
+            Int64 selectedPtr = Scanner.READ_LONGLONG(Address.BASE + 0x4ECB740);
+            bool isSelect = Scanner.READ_LONGLONG(selectedPtr + 0x128) != 0x0 && Scanner.READ_LONGLONG(selectedPtr + 0x130) != 0x0 && Scanner.READ_LONGLONG(selectedPtr + 0x160) != 0x0;
+            //Int64 SelectedMonsterAddress = Scanner.READ_LONGLONG(selectedPtr + 0x148); // don't actually need this as it will be the same as TargettedMonsterAddress if isSelect is true
+            if (!isSelect) {
+                this.IsSelect = 0; // nothing is selected
+            } else if (TargettedMonsterAddress == this.MonsterAddress) {
+                this.IsSelect = 1; // this monster is selected
+            } else {
+                this.IsSelect = 2; // another monster is selected
+            }
         }
 
         private void CreateMonsterParts(int numberOfParts) {

--- a/HunterPie/GUI/Widgets/Monster Widget/MonsterHealth.xaml.cs
+++ b/HunterPie/GUI/Widgets/Monster Widget/MonsterHealth.xaml.cs
@@ -284,8 +284,29 @@ namespace HunterPie.GUI.Widgets {
                 case 3: // Show all but hide unactive monsters
                     ShowAllMonsterAndHideUnactive();
                     break;
+                case 4: // Show all or only selected monster
+                    ShowAllOrSelected();
+                    break;
             }
         }
+
+        // Show all monsters or the selected one (if any)
+        private void ShowAllOrSelected()
+        {
+            if (this.Context == null || !this.Context.IsAlive) { this.Visibility = Visibility.Collapsed; return; }
+            else { this.Visibility = Visibility.Visible; }
+            if (this.Context.IsSelect == 1) { // this monster selected
+                this.Width = 500;
+                ChangeBarsSizes(Width);
+                this.Opacity = 1;
+            } else if (this.Context.IsSelect == 0) { // nothing selected, show all
+                this.Width = 300;
+                ChangeBarsSizes(Width);
+                this.Opacity = 1;
+            }
+            else { this.Visibility = Visibility.Collapsed; } // another monster selected, hide this monster
+        }
+
 
         // Show all monsters but hide unactive
         private void ShowAllMonsterAndHideUnactive() {

--- a/HunterPie/Hunterpie.xaml.cs
+++ b/HunterPie/Hunterpie.xaml.cs
@@ -197,7 +197,7 @@ namespace HunterPie {
                             UserSettings.SaveNewConfig();
                             break;
                         case 1: // Switch monster bar mode
-                            UserSettings.PlayerConfig.Overlay.MonstersComponent.ShowMonsterBarMode = UserSettings.PlayerConfig.Overlay.MonstersComponent.ShowMonsterBarMode + 1 >= 4 ? (byte)0 : (byte)(UserSettings.PlayerConfig.Overlay.MonstersComponent.ShowMonsterBarMode + 1);
+                            UserSettings.PlayerConfig.Overlay.MonstersComponent.ShowMonsterBarMode = UserSettings.PlayerConfig.Overlay.MonstersComponent.ShowMonsterBarMode + 1 >= 5 ? (byte)0 : (byte)(UserSettings.PlayerConfig.Overlay.MonstersComponent.ShowMonsterBarMode + 1);
                             UserSettings.SaveNewConfig();
                             break;
                     }


### PR DESCRIPTION
This is more of a suggestion than just a pure pullrequest but I figured providing code would both illustrate what I am suggestion and allow for quick practical testing. It is a combination (of sorts) of mode ShowAllMonstersAtOnce() and ShowOnlyTargetMonster() but also has a unique 'quality' to it. 

The idea was to have one mode for expeditions and guiding lands where you can see all monsters until you choose to select one, in which case it is centered and the others are hidden. All without switching between modes a few times. 

There's also a difference between 'targeted' (when the monster icon has two swirling green dots) and 'selected' (when the monster has a green pin on it). When something is 'selected' it is also 'targeted' but not the other way around. 

When you try things out you may notice that during a quest it's still required to manually select the hunted monster in order to only show that one (because of the above). This is by design as it means the user will always see all monsters (and, for example, their crowns) while still allowing simple but direct control over which monster is shown/singled out.  It can also be useful for multi-monster quests as it wouldn't show just the first hunted monster straight away.

Note: I haven't done any setting/string changes as I did most during the translation process and didn't wanna end up with a bunch of (unneeded) conflicts once I'd make a pull request.

Note2: An alternative to all this could be to change ShowOnlyTargetMonster() to display all of them if there is no target monster tho that would then still automatically show the target monster in quests (instead of letting the user select one manually).