### PR TITLE
Remove XML re-parsing from Player Abnormalities

### DIFF
--- a/HunterPie/Core/Client/GStrings.cs
+++ b/HunterPie/Core/Client/GStrings.cs
@@ -54,7 +54,7 @@ namespace HunterPie.Core {
             return Stage?.Attributes["Name"].Value;
         }
 
-        public static string GetAbnormalityByID(string Type, int ID, byte Stack) {
+        public static string GetAbnormalityByID(string Type, int ID, int Stack) {
             XmlNode Abnormality = Translations.SelectSingleNode($"//Strings/Abnormalities/Abnormality[@ID='{Type}_{ID:000}_{Stack:00}']");
             if (Abnormality == null) {
                 Abnormality = Translations.SelectSingleNode($"//Strings/Abnormalities/Abnormality[@ID='{Type}_{ID:000}_{0:00}']");

--- a/HunterPie/Core/LPlayer/Abnormalities.cs
+++ b/HunterPie/Core/LPlayer/Abnormalities.cs
@@ -35,7 +35,7 @@ namespace HunterPie.Core {
             CurrentAbnormalities.Add(AbnormId, Abnorm);
             _OnNewAbnormality(CurrentAbnormalities[AbnormId]);
             CurrentAbnormalities[AbnormId].OnAbnormalityEnd += RemoveObsoleteAbnormality;
-            //Logger.Debugger.Log($"NEW ABNORMALITY: {Abnorm.Name} (ID: {Abnorm.ID})");
+            // Logger.Debugger.Debug($"NEW ABNORMALITY: {Abnorm.Name} (ID: {Abnorm.Id})");
         }
 
         public void Remove(string AbnormId) {

--- a/HunterPie/Core/LPlayer/Abnormality.cs
+++ b/HunterPie/Core/LPlayer/Abnormality.cs
@@ -1,25 +1,50 @@
-﻿namespace HunterPie.Core {
-    public class Abnormality {
-        private int _Duration { get; set; }
+﻿using HunterPie.Core.LPlayer;
 
-        public string Name {
-            get { return GStrings.GetAbnormalityByID(Type, ID, Stack); }
+namespace HunterPie.Core {
+    public class Abnormality
+    {
+        private int duration;
+        private byte stack;
+
+        public Abnormality(AbnormalityInfo info)
+        {
+            Type = info.Type;
+            Id = info.Id;
+            InternalID = info.InternalId;
+            IsDebuff = info.IsDebuff;
+            IsInfinite = info.IsInfinite;
+            Icon = info.IconName;
         }
+
+        public string Name => GStrings.GetAbnormalityByID(Type, Id, Stack);
         public string Icon { get; private set; }
         public string Type { get; private set; }
-        public int ID { get; private set; }
-        public byte Stack { get; private set; }
+        public int Id { get; private set; }
+
+        public byte Stack
+        {
+            get => stack;
+            private set
+            {
+                if (stack != value)
+                {
+                    stack = value;
+                    _OnStackChange();
+                }
+            }
+        }
+
         public string InternalID { get; private set; }
         public bool IsInfinite { get; private set; }
         public int Duration {
-            get { return _Duration; }
-            set {
+            get => duration;
+            private set {
                 if (value <= 0 && !IsInfinite) {
                     _OnAbnormalityEnd();
                     return;
                 }
-                if (value != _Duration) {
-                    _Duration = value;
+                if (value != duration) {
+                    duration = value;
                     _OnAbnormalityUpdate();
                 }
             }
@@ -56,26 +81,17 @@
 
         #region Methods
 
-        public void UpdateAbnormalityInfo(string Type, string InternalID,float ab_duration, byte ab_stack, int ab_id, bool ab_isDebuff, bool IsInfinite, string icon) {
-            this.Type = Type;
-            this.Icon = icon;
-            this.InternalID = InternalID;
-            this.MaxDuration = MaxDuration < ab_duration ? ab_duration : MaxDuration;
-            if (this.Stack != ab_stack) {
-                this.Stack = (byte)(ab_stack);
-                _OnStackChange();
-            }
-            if (MaxDuration > 0) { this.DurationPercentage = ab_duration / MaxDuration; }
-            else { this.DurationPercentage = 1; }
-            this.IsDebuff = ab_isDebuff;
-            this.IsInfinite = IsInfinite;
-            this.Duration = (int)ab_duration;
-            this.ID = ab_id;
+        public void UpdateAbnormalityInfo(float newDuration, byte newStack)
+        {
+            Stack = newStack;
+            Duration = (int)newDuration;
+            MaxDuration = MaxDuration < newDuration ? newDuration : MaxDuration;
+            DurationPercentage = MaxDuration > 0 ? newDuration / MaxDuration : 1;
         }
 
         public void ResetDuration() {
-            this.IsInfinite = false;
-            this.Duration = 0;
+            IsInfinite = false;
+            Duration = 0;
         }
 
         #endregion

--- a/HunterPie/Core/LPlayer/AbnormalityData.cs
+++ b/HunterPie/Core/LPlayer/AbnormalityData.cs
@@ -2,53 +2,100 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
+using HunterPie.Core.LPlayer;
 using HunterPie.Logger;
-using HunterPie.Properties;
 
 namespace HunterPie.Core {
     public class AbnormalityData {
         private static XmlDocument AbnormalitiesData;
+        private static List<AbnormalityInfo> huntingHornAbnormalities;
+        private static List<AbnormalityInfo> palicoAbnormalities;
+        private static List<AbnormalityInfo> blightAbnormalities;
+        private static List<AbnormalityInfo> miscAbnormalities;
+        private static List<AbnormalityInfo> gearAbnormalities;
+
+        public static IReadOnlyCollection<AbnormalityInfo> HuntingHornAbnormalities => huntingHornAbnormalities;
+        public static IReadOnlyCollection<AbnormalityInfo> PalicoAbnormalities => palicoAbnormalities;
+        public static IReadOnlyCollection<AbnormalityInfo> BlightAbnormalities => blightAbnormalities;
+        public static IReadOnlyCollection<AbnormalityInfo> MiscAbnormalities => miscAbnormalities;
+        public static IReadOnlyCollection<AbnormalityInfo> GearAbnormalities => gearAbnormalities;
 
         static public void LoadAbnormalityData() {
             AbnormalitiesData = new XmlDocument();
             AbnormalitiesData.Load(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "HunterPie.Resources/Data/AbnormalityData.xml"));
             Debugger.Warn(GStrings.GetLocalizationByXPath("/Console/String[@ID='MESSAGE_ABNORMALITIES_DATA_LOAD']"));
+
+            LoadHuntingHornAbnormalities();
+            LoadPalicoAbnormalities();
+            LoadBlightAbnormalities();
+            LoadMiscAbnormalities();
+            LoadGearAbnormalities();
         }
 
-        static public XmlNodeList GetHuntingHornAbnormalities() {
-            XmlNodeList HuntingHornAbnormalitiesData = AbnormalitiesData.SelectNodes("//Abnormalities/HUNTINGHORN_Abnormalities/Abnormality");
-            return HuntingHornAbnormalitiesData;
+        private static void LoadHuntingHornAbnormalities()
+        {
+            huntingHornAbnormalities = LoadAbnormalityType("HUNTINGHORN", "HH", "//Abnormalities/HUNTINGHORN_Abnormalities/Abnormality");
         }
 
-        static public XmlNodeList GetPalicoAbnormalities() {
-            XmlNodeList PalicoAbnormalitiesData = AbnormalitiesData.SelectNodes("//Abnormalities/PALICO_Abnormalities/Abnormality");
-            return PalicoAbnormalitiesData;
+        private static void LoadPalicoAbnormalities()
+        {
+            palicoAbnormalities = LoadAbnormalityType("PALICO", "PAL", "//Abnormalities/PALICO_Abnormalities/Abnormality");
         }
 
-        static public XmlNodeList GetBlightAbnormalities() {
-            XmlNodeList BlightAbnormalitiesData = AbnormalitiesData.SelectNodes("//Abnormalities/DEBUFF_Abnormalities/Abnormality");
-            return BlightAbnormalitiesData;
+        private static void LoadBlightAbnormalities()
+        {
+            blightAbnormalities = LoadAbnormalityType("DEBUFF", "DE", "//Abnormalities/DEBUFF_Abnormalities/Abnormality");
         }
 
-        static public XmlNodeList GetMiscAbnormalities() {
-            XmlNodeList MiscAbnormalitiesData = AbnormalitiesData.SelectNodes("//Abnormalities/MISC_Abnormalities/Abnormality");
-            return MiscAbnormalitiesData;
+        private static void LoadMiscAbnormalities()
+        {
+            miscAbnormalities = LoadAbnormalityType("MISC", "MISC", "//Abnormalities/MISC_Abnormalities/Abnormality");
         }
 
-        static public XmlNodeList GetGearAbnormalities() {
-            XmlNodeList GearAbnormalitiesData = AbnormalitiesData.SelectNodes("//Abnormalities/GEAR_Abnormalities/Abnormality");
-            return GearAbnormalitiesData;
+        private static void LoadGearAbnormalities() {
+            gearAbnormalities = LoadAbnormalityType("GEAR", "GEAR", "//Abnormalities/GEAR_Abnormalities/Abnormality");
         }
 
-        static public string GetAbnormalityIconByID(string Type, int ID) {
-            XmlNode Abnormality = AbnormalitiesData.SelectSingleNode($"//Abnormalities/{Type}_Abnormalities/Abnormality[@ID='{ID}']");
-            string IconName = Abnormality?.Attributes["Icon"].Value;
-            IconName = string.IsNullOrEmpty(IconName) ? "ICON_MISSING" : IconName;
-            return IconName;
+        private static List<AbnormalityInfo> LoadAbnormalityType(string type, string idPrefix, string xmlSelector)
+        {
+            XmlNodeList nodes = AbnormalitiesData
+                .SelectNodes(xmlSelector) ?? throw new Exception("Could not get XML Abnormality nodes");
+
+            return nodes
+                .Cast<XmlNode>()
+                .Select(node => AbnormalityXmlNodeToInfo(node, type, idPrefix))
+                .ToList();
         }
 
+        private static AbnormalityInfo AbnormalityXmlNodeToInfo(XmlNode node, string type, string idPrefix)
+        {
+            if (node?.Attributes == null)
+            {
+                throw new ArgumentNullException(nameof(node), "XmlNode and its attributes cannot be null!");
+            }
+
+            AbnormalityInfo abnormality = new AbnormalityInfo
+            {
+                Id = int.Parse(node.Attributes["ID"].Value),
+                Type = type,
+                Offset = int.Parse(node.Attributes["Offset"].Value, System.Globalization.NumberStyles.HexNumber),
+                IsDebuff = bool.Parse(node.Attributes["IsDebuff"]?.Value ?? "False"),
+                IsGearBuff = bool.Parse(node.Attributes["IsGearBuff"]?.Value ?? "False"),
+                IsInfinite = bool.Parse(node.Attributes["IsInfinite"]?.Value ?? "False"),
+                IconName = node.Attributes["Icon"]?.Value,
+                HasConditions = bool.Parse(node.Attributes["HasConditions"]?.Value ?? "False"),
+                ConditionOffset = int.Parse(node.Attributes["ConditionOffset"]?.Value ?? "0"),
+                Stack = int.Parse(node.Attributes["Stack"]?.Value ?? "0"),
+            };
+
+            abnormality.InternalId = $"{idPrefix}_{abnormality.Id}";
+            if (string.IsNullOrEmpty(abnormality.IconName))
+            {
+                abnormality.IconName = "ICON_MISSING";
+            }
+
+            return abnormality;
+        }
     }
 }

--- a/HunterPie/Core/LPlayer/AbnormalityInfo.cs
+++ b/HunterPie/Core/LPlayer/AbnormalityInfo.cs
@@ -1,0 +1,20 @@
+﻿namespace HunterPie.Core.LPlayer
+{
+    public class AbnormalityInfo
+    {
+        public int Id { get; set; }
+        public string InternalId { get; set; }
+        public int Offset { get; set; }
+        public string Type { get; set; }
+        public bool IsDebuff { get; set; }
+        public bool IsGearBuff { get; set; }
+        public bool IsInfinite { get; set; }
+
+        public bool HasConditions { get; set; }
+        public int ConditionOffset { get; set; }
+
+        public int Stack { get; set; }
+
+        public string IconName { get; set; }
+    }
+}

--- a/HunterPie/GUI/Widgets/Abnormality Widget/AbnormalityContainer.xaml.cs
+++ b/HunterPie/GUI/Widgets/Abnormality Widget/AbnormalityContainer.xaml.cs
@@ -18,6 +18,7 @@ namespace HunterPie.GUI.Widgets.Abnormality_Widget {
         Player Context;
         public int AbnormalityTrayIndex;
         private int MaxSize;
+        private UserSettings.Config.AbnormalityBar preset;
 
         public AbnormalityContainer(Player context, int TrayIndex) {
             InitializeComponent();
@@ -25,6 +26,7 @@ namespace HunterPie.GUI.Widgets.Abnormality_Widget {
             BaseHeight = Height;
             WidgetType = 5;
             AbnormalityTrayIndex = TrayIndex;
+            preset = UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex];
             ApplySettings();
             SetWindowFlags();
             SetContext(context);
@@ -37,12 +39,12 @@ namespace HunterPie.GUI.Widgets.Abnormality_Widget {
             }
             Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Background, new Action(() => {
                 if (!FocusTrigger) {
-                    this.WidgetActive = UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex].Enabled;
-                    this.Top = UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex].Position[1] + UserSettings.PlayerConfig.Overlay.Position[1];
-                    this.Left = UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex].Position[0] + UserSettings.PlayerConfig.Overlay.Position[0];
-                    this.BuffTray.Orientation = UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex].Orientation == "Horizontal" ? UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex].ShowNames ? Orientation.Vertical : Orientation.Horizontal : Orientation.Vertical;
-                    this.BackgroundTray.Opacity = UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex].BackgroundOpacity;
-                    int BuffTrayMaxSize = Math.Max(UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex].MaxSize, 0);
+                    this.WidgetActive = preset.Enabled;
+                    this.Top = preset.Position[1] + UserSettings.PlayerConfig.Overlay.Position[1];
+                    this.Left = preset.Position[0] + UserSettings.PlayerConfig.Overlay.Position[0];
+                    this.BuffTray.Orientation = preset.Orientation == "Horizontal" ? preset.ShowNames ? Orientation.Vertical : Orientation.Horizontal : Orientation.Vertical;
+                    this.BackgroundTray.Opacity = preset.BackgroundOpacity;
+                    int BuffTrayMaxSize = Math.Max(preset.MaxSize, 0);
                     if (BuffTrayMaxSize > 7000) BuffTrayMaxSize = 0;
                     if (this.BuffTray.Orientation == Orientation.Horizontal) {
                         this.BuffTray.MaxWidth = BuffTrayMaxSize == 0 ? 300 : BuffTrayMaxSize;
@@ -59,7 +61,7 @@ namespace HunterPie.GUI.Widgets.Abnormality_Widget {
                             this.Width = BuffTray.MinWidth;
                         }
                     }
-                    ScaleWidget(UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex].Scale, UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex].Scale);
+                    ScaleWidget(preset.Scale, preset.Scale);
                 }
                 base.ApplySettings();
             }));
@@ -70,11 +72,11 @@ namespace HunterPie.GUI.Widgets.Abnormality_Widget {
                 this.Close();
                 return;
             }
-            UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex].Position[0] = (int)Left - UserSettings.PlayerConfig.Overlay.Position[0];
-            UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex].Position[1] = (int)Top - UserSettings.PlayerConfig.Overlay.Position[1];
-            UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex].MaxSize = this.MaxSize;
-            UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex].Orientation = BuffTray.Orientation == Orientation.Horizontal ? "Horizontal" : "Vertical";
-            UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex].Scale = DefaultScaleX;
+            preset.Position[0] = (int)Left - UserSettings.PlayerConfig.Overlay.Position[0];
+            preset.Position[1] = (int)Top - UserSettings.PlayerConfig.Overlay.Position[1];
+            preset.MaxSize = this.MaxSize;
+            preset.Orientation = BuffTray.Orientation == Orientation.Horizontal ? "Horizontal" : "Vertical";
+            preset.Scale = DefaultScaleX;
         }
 
         private void SetContext(Player ctx) {
@@ -128,13 +130,13 @@ namespace HunterPie.GUI.Widgets.Abnormality_Widget {
 
         private void OnPlayerNewAbnormality(object source, AbnormalityEventArgs args) {
             // Ignore abnormalities that aren't enabled for this tray
-            if (!UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex].AcceptedAbnormalities.Contains(args.Abnormality.InternalID)) return;
+            if (!preset.AcceptedAbnormalities.Contains(args.Abnormality.InternalID)) return;
             Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Loaded, new Action(() => {
                 this.WidgetHasContent = true;
                 Parts.AbnormalityControl AbnormalityBox = new Parts.AbnormalityControl() {
-                    ShowAbnormalityTimerText = UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex].ShowTimeLeftText,
-                    AbnormalityTimerTextFormat = UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex].TimeLeftTextFormat,
-                    ShowAbnormalityName = UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex].ShowNames
+                    ShowAbnormalityTimerText = preset.ShowTimeLeftText,
+                    AbnormalityTimerTextFormat = preset.TimeLeftTextFormat,
+                    ShowAbnormalityName = preset.ShowNames
                 };
                 AbnormalityBox.Initialize(args.Abnormality);
                 this.ActiveAbnormalities.Add(args.Abnormality.InternalID, AbnormalityBox);
@@ -191,9 +193,9 @@ namespace HunterPie.GUI.Widgets.Abnormality_Widget {
             if (e.LeftButton == MouseButtonState.Pressed) {
                 this.ResizeMode = ResizeMode.NoResize;
                 this.MoveWidget();
-                UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex].Position[0] = (int)Left - UserSettings.PlayerConfig.Overlay.Position[0];
-                UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex].Position[1] = (int)Top - UserSettings.PlayerConfig.Overlay.Position[1];
-                UserSettings.PlayerConfig.Overlay.AbnormalitiesWidget.BarPresets[AbnormalityTrayIndex].Scale = DefaultScaleX;
+                preset.Position[0] = (int)Left - UserSettings.PlayerConfig.Overlay.Position[0];
+                preset.Position[1] = (int)Top - UserSettings.PlayerConfig.Overlay.Position[1];
+                preset.Scale = DefaultScaleX;
             }
             if (e.LeftButton == MouseButtonState.Released) {
                 this.ResizeMode = ResizeMode.CanResizeWithGrip;

--- a/HunterPie/GUIControls/Custom Controls/BuffBarSettingControl.xaml.cs
+++ b/HunterPie/GUIControls/Custom Controls/BuffBarSettingControl.xaml.cs
@@ -27,7 +27,7 @@ namespace HunterPie.GUIControls.Custom_Controls {
 
         private void OnBuffTraySettingClick(object sender, System.Windows.Input.MouseButtonEventArgs e) {
             if (TraySettingsWindow == null || TraySettingsWindow.IsClosed) {
-                TraySettingsWindow = new AbnormalityTraySettings(TrayIndex: TrayIndex);
+                TraySettingsWindow = new AbnormalityTraySettings(trayIndex: TrayIndex);
             }
             TraySettingsWindow.Show();
         }

--- a/HunterPie/HunterPie.Resources/Data/AbnormalityData.xml
+++ b/HunterPie/HunterPie.Resources/Data/AbnormalityData.xml
@@ -1,76 +1,76 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Abnormalities>
   <HUNTINGHORN_Abnormalities>
-    <Abnormality ID="0" IsDebuff="False" Offset="38" Icon="ICON_SELFIMPROVEMENT" Stack="0"/>
-    <Abnormality ID="999" IsDebuff="False" Offset="38" Icon="ICON_ATTACKUP" Stack="1"/>
-    <Abnormality ID="1" IsDebuff="False" Offset="3C" Icon="ICON_ATTACKUP" Stack="0"/>
-    <Abnormality ID="2" IsDebuff="False" Offset="40" Icon="ICON_ATTACKUP" Stack="0"/>
-    <Abnormality ID="3" IsDebuff="False" Offset="44" Icon="ICON_HEALTHUP" Stack="0"/>
-    <Abnormality ID="4" IsDebuff="False" Offset="48" Icon="ICON_HEALTHUP" Stack="0"/>
-    <Abnormality ID="5" IsDebuff="False" Offset="4C" Icon="ICON_STAMINAUP" Stack="0"/>
-    <Abnormality ID="6" IsDebuff="False" Offset="50" Icon="ICON_STAMINAUP" Stack="0"/>
-    <Abnormality ID="7" IsDebuff="False" Offset="54" Icon="ICON_WINDRES" Stack="0"/>
-    <Abnormality ID="8" IsDebuff="False" Offset="58" Icon="ICON_WINDRES+" Stack="0"/>
-    <Abnormality ID="9" IsDebuff="False" Offset="5C" Icon="ICON_DEFUP" Stack="0"/>
-    <Abnormality ID="10" IsDebuff="False" Offset="60" Icon="ICON_DEFUP" Stack="0"/>
-    <Abnormality ID="11" IsDebuff="False" Offset="64" Icon="ICON_MANTLEUP" Stack="0"/>
-    <Abnormality ID="12" IsDebuff="False" Offset="68" Icon="ICON_MANTLEUP" Stack="0"/>
-    <Abnormality ID="18" IsDebuff="False" Offset="80" Icon="ICON_NATURALHEALING" Stack="0"/>
-    <Abnormality ID="19" IsDebuff="False" Offset="84" Icon="ICON_NATURALHEALING" Stack="0"/>
-    <Abnormality ID="20" IsDebuff="False" Offset="88" Icon="ICON_EARPLUGS" Stack="0"/>
-    <Abnormality ID="21" IsDebuff="False" Offset="8C" Icon="ICON_EARPLUGS+" Stack="0"/>
-    <Abnormality ID="22" IsDebuff="False" Offset="90" Icon="ICON_DIVINEPROTECTION" Stack="0"/>
-    <Abnormality ID="23" IsDebuff="False" Offset="94" Icon="ICON_SCOUTFLYUP" Stack="0"/>
-    <Abnormality ID="24" IsDebuff="False" Offset="98" Icon="ICON_ENVNEG" Stack="0"/>
-    <Abnormality ID="25" IsDebuff="False" Offset="9C" Icon="ICON_STUNNEG" Stack="0"/>
-    <Abnormality ID="26" IsDebuff="False" Offset="A0" Icon="ICON_PARALYSISNEG" Stack="0"/>
-    <Abnormality ID="27" IsDebuff="False" Offset="A4" Icon="ICON_TREMORNEG" Stack="0"/>
-    <Abnormality ID="28" IsDebuff="False" Offset="A8" Icon="ICON_DEEPRES" Stack="0"/>
-    <Abnormality ID="29" IsDebuff="False" Offset="AC" Icon="ICON_FIRERES" Stack="0"/>
-    <Abnormality ID="30" IsDebuff="False" Offset="B0" Icon="ICON_FIRERES+" Stack="0"/>
-    <Abnormality ID="31" IsDebuff="False" Offset="B4" Icon="ICON_WATERRES" Stack="0"/>
-    <Abnormality ID="32" IsDebuff="False" Offset="B8" Icon="ICON_WATERRES+" Stack="0"/>
-    <Abnormality ID="33" IsDebuff="False" Offset="BC" Icon="ICON_THUNDERRES" Stack="0"/>
-    <Abnormality ID="34" IsDebuff="False" Offset="C0" Icon="ICON_THUNDERRES+" Stack="0"/>
-    <Abnormality ID="35" IsDebuff="False" Offset="C4" Icon="ICON_ICERES" Stack="0"/>
-    <Abnormality ID="36" IsDebuff="False" Offset="C8" Icon="ICON_ICERES+" Stack="0"/>
-    <Abnormality ID="37" IsDebuff="False" Offset="CC" Icon="ICON_DRAGONRES" Stack="0"/>
-    <Abnormality ID="38" IsDebuff="False" Offset="D0" Icon="ICON_DRAGONRES+" Stack="0"/>
-    <Abnormality ID="39" IsDebuff="False" Offset="D4" Icon="ICON_ELEATTACKUP" Stack="0"/>
-    <Abnormality ID="40" IsDebuff="False" Offset="D8" Icon="ICON_BLIGHTSNEG" Stack="0"/>
-    <Abnormality ID="41" IsDebuff="False" Offset="DC" Icon="" Stack="0"/>
-    <Abnormality ID="43" IsDebuff="False" Offset="E4" Icon="ICON_KNOCKBACKNEG" Stack="0"/>
-    <Abnormality ID="45" IsDebuff="False" Offset="EC" Icon="ICON_ALLRESUP" Stack="0"/>
-    <Abnormality ID="46" IsDebuff="False" Offset="F0" Icon="ICON_AFFINITY" Stack="0"/>
-    <Abnormality ID="47" IsDebuff="False" Offset="F4" Icon="ICON_AILMENTSNEG" Stack="0"/>
-    <Abnormality ID="48" IsDebuff="False" Offset="F8" Icon="ICON_EARPLUGS" Stack="0"/>
-    <Abnormality ID="49" IsDebuff="False" Offset="FC" Icon="ICON_ABNORMATTACKUP" Stack="0"/>
-    <Abnormality ID="53" IsDebuff="False" Offset="10C" Icon="ICON_MAXSTAMRECOVERY" Stack="0"/>
-    <Abnormality ID="54" IsDebuff="False" Offset="110" Icon="ICON_EXT_HEALTHRECOVERY" Stack="0"/>
-    <Abnormality ID="55" IsDebuff="False" Offset="114" Icon="ICON_EVASION" Stack="0"/>
-    <Abnormality ID="56" IsDebuff="False" Offset="118" Icon="ICON_ALLRESUP" Stack="0"/>
-    <Abnormality ID="943" IsDebuff="False" Offset="118" Icon="ICON_ELEATTACKUP" Stack="0"/>
+    <Abnormality ID="0" Offset="38" Icon="ICON_SELFIMPROVEMENT"/>
+    <Abnormality ID="999" Offset="38" Icon="ICON_ATTACKUP" Stack="1"/>
+    <Abnormality ID="1" Offset="3C" Icon="ICON_ATTACKUP"/>
+    <Abnormality ID="2" Offset="40" Icon="ICON_ATTACKUP"/>
+    <Abnormality ID="3" Offset="44" Icon="ICON_HEALTHUP"/>
+    <Abnormality ID="4" Offset="48" Icon="ICON_HEALTHUP"/>
+    <Abnormality ID="5" Offset="4C" Icon="ICON_STAMINAUP"/>
+    <Abnormality ID="6" Offset="50" Icon="ICON_STAMINAUP"/>
+    <Abnormality ID="7" Offset="54" Icon="ICON_WINDRES"/>
+    <Abnormality ID="8" Offset="58" Icon="ICON_WINDRES+"/>
+    <Abnormality ID="9" Offset="5C" Icon="ICON_DEFUP"/>
+    <Abnormality ID="10" Offset="60" Icon="ICON_DEFUP"/>
+    <Abnormality ID="11" Offset="64" Icon="ICON_MANTLEUP"/>
+    <Abnormality ID="12" Offset="68" Icon="ICON_MANTLEUP"/>
+    <Abnormality ID="18" Offset="80" Icon="ICON_NATURALHEALING"/>
+    <Abnormality ID="19" Offset="84" Icon="ICON_NATURALHEALING"/>
+    <Abnormality ID="20" Offset="88" Icon="ICON_EARPLUGS"/>
+    <Abnormality ID="21" Offset="8C" Icon="ICON_EARPLUGS+"/>
+    <Abnormality ID="22" Offset="90" Icon="ICON_DIVINEPROTECTION"/>
+    <Abnormality ID="23" Offset="94" Icon="ICON_SCOUTFLYUP"/>
+    <Abnormality ID="24" Offset="98" Icon="ICON_ENVNEG"/>
+    <Abnormality ID="25" Offset="9C" Icon="ICON_STUNNEG"/>
+    <Abnormality ID="26" Offset="A0" Icon="ICON_PARALYSISNEG"/>
+    <Abnormality ID="27" Offset="A4" Icon="ICON_TREMORNEG"/>
+    <Abnormality ID="28" Offset="A8" Icon="ICON_DEEPRES"/>
+    <Abnormality ID="29" Offset="AC" Icon="ICON_FIRERES"/>
+    <Abnormality ID="30" Offset="B0" Icon="ICON_FIRERES+"/>
+    <Abnormality ID="31" Offset="B4" Icon="ICON_WATERRES"/>
+    <Abnormality ID="32" Offset="B8" Icon="ICON_WATERRES+"/>
+    <Abnormality ID="33" Offset="BC" Icon="ICON_THUNDERRES"/>
+    <Abnormality ID="34" Offset="C0" Icon="ICON_THUNDERRES+"/>
+    <Abnormality ID="35" Offset="C4" Icon="ICON_ICERES"/>
+    <Abnormality ID="36" Offset="C8" Icon="ICON_ICERES+"/>
+    <Abnormality ID="37" Offset="CC" Icon="ICON_DRAGONRES"/>
+    <Abnormality ID="38" Offset="D0" Icon="ICON_DRAGONRES+"/>
+    <Abnormality ID="39" Offset="D4" Icon="ICON_ELEATTACKUP"/>
+    <Abnormality ID="40" Offset="D8" Icon="ICON_BLIGHTSNEG"/>
+    <Abnormality ID="41" Offset="DC"/>
+    <Abnormality ID="43" Offset="E4" Icon="ICON_KNOCKBACKNEG"/>
+    <Abnormality ID="45" Offset="EC" Icon="ICON_ALLRESUP"/>
+    <Abnormality ID="46" Offset="F0" Icon="ICON_AFFINITY"/>
+    <Abnormality ID="47" Offset="F4" Icon="ICON_AILMENTSNEG"/>
+    <Abnormality ID="48" Offset="F8" Icon="ICON_EARPLUGS"/>
+    <Abnormality ID="49" Offset="FC" Icon="ICON_ABNORMATTACKUP"/>
+    <Abnormality ID="53" Offset="10C" Icon="ICON_MAXSTAMRECOVERY"/>
+    <Abnormality ID="54" Offset="110" Icon="ICON_EXT_HEALTHRECOVERY"/>
+    <Abnormality ID="55" Offset="114" Icon="ICON_EVASION"/>
+    <Abnormality ID="56" Offset="118" Icon="ICON_ALLRESUP"/>
+    <Abnormality ID="943" Offset="118" Icon="ICON_ELEATTACKUP"/>
   </HUNTINGHORN_Abnormalities>
   <PALICO_Abnormalities>
-    <Abnormality ID="0" IsDebuff="False" Offset="11C" Icon="ICON_EVASION"/>
-    <Abnormality ID="1" IsDebuff="False" Offset="120" Icon="ICON_ATTACKUP"/>
-    <Abnormality ID="2" IsDebuff="False" Offset="124" Icon="ICON_ATTACKUP"/>
-    <Abnormality ID="3" IsDebuff="False" Offset="128" Icon="ICON_DEFUP"/>
-    <Abnormality ID="4" IsDebuff="False" Offset="12C" Icon="ICON_DEFUP"/>
-    <Abnormality ID="5" IsDebuff="False" Offset="130" Icon="ICON_AFFINITY"/>
-    <Abnormality ID="6" IsDebuff="False" Offset="134" Icon="ICON_NATURALHEALING"/>
-    <Abnormality ID="7" IsDebuff="False" Offset="138" Icon="ICON_HEALTHUP"/>
-    <Abnormality ID="8" IsDebuff="False" Offset="13C" Icon="ICON_STAMINAUP"/>
-    <Abnormality ID="9" IsDebuff="False" Offset="140" Icon=""/>
-    <Abnormality ID="10" IsDebuff="False" Offset="144" Icon="ICON_DIVINEPROTECTION"/>
-    <Abnormality ID="11" IsDebuff="False" Offset="148" Icon="ICON_DIVINEPROTECTION"/>
-    <Abnormality ID="12" IsDebuff="False" Offset="14C" Icon="ICON_STUNNEG"/>
-    <Abnormality ID="13" IsDebuff="False" Offset="150" Icon="ICON_PARALYSISNEG"/>
-    <Abnormality ID="14" IsDebuff="False" Offset="154" Icon="ICON_TREMORNEG"/>
-    <Abnormality ID="15" IsDebuff="False" Offset="158" Icon="ICON_EARPLUGS"/>
-    <Abnormality ID="16" IsDebuff="False" Offset="15C" Icon="ICON_WINDRES+"/>
-    <Abnormality ID="17" IsDebuff="False" Offset="160" Icon="ICON_ENVNEG"/>
-    <Abnormality ID="18" IsDebuff="False" Offset="164" Icon=""/>
+    <Abnormality ID="0" Offset="11C" Icon="ICON_EVASION"/>
+    <Abnormality ID="1" Offset="120" Icon="ICON_ATTACKUP"/>
+    <Abnormality ID="2" Offset="124" Icon="ICON_ATTACKUP"/>
+    <Abnormality ID="3" Offset="128" Icon="ICON_DEFUP"/>
+    <Abnormality ID="4" Offset="12C" Icon="ICON_DEFUP"/>
+    <Abnormality ID="5" Offset="130" Icon="ICON_AFFINITY"/>
+    <Abnormality ID="6" Offset="134" Icon="ICON_NATURALHEALING"/>
+    <Abnormality ID="7" Offset="138" Icon="ICON_HEALTHUP"/>
+    <Abnormality ID="8" Offset="13C" Icon="ICON_STAMINAUP"/>
+    <Abnormality ID="9" Offset="140"/>
+    <Abnormality ID="10" Offset="144" Icon="ICON_DIVINEPROTECTION"/>
+    <Abnormality ID="11" Offset="148" Icon="ICON_DIVINEPROTECTION"/>
+    <Abnormality ID="12" Offset="14C" Icon="ICON_STUNNEG"/>
+    <Abnormality ID="13" Offset="150" Icon="ICON_PARALYSISNEG"/>
+    <Abnormality ID="14" Offset="154" Icon="ICON_TREMORNEG"/>
+    <Abnormality ID="15" Offset="158" Icon="ICON_EARPLUGS"/>
+    <Abnormality ID="16" Offset="15C" Icon="ICON_WINDRES+"/>
+    <Abnormality ID="17" Offset="160" Icon="ICON_ENVNEG"/>
+    <Abnormality ID="18" Offset="164"/>
   </PALICO_Abnormalities>
   <DEBUFF_Abnormalities>
     <Abnormality ID="0" IsDebuff="True" Offset="5DC" Icon="ICON_POISON"/>
@@ -85,38 +85,38 @@
     <Abnormality ID="11" IsDebuff="True" Offset="608" Icon="ICON_EFFLUVIA"/>
     <Abnormality ID="12" IsDebuff="True" Offset="60C" Icon="ICON_DEFDOWN"/>
     <Abnormality ID="14" IsDebuff="True" Offset="614" Icon="ICON_ALLRESDOWN"/>
-    <Abnormality ID="16" IsDebuff="True" Offset="61C" Icon=""/>
+    <Abnormality ID="16" IsDebuff="True" Offset="61C"/>
     <Abnormality ID="17" IsDebuff="True" Offset="620" Icon="ICON_BLAST"/>
     <Abnormality ID="20" IsDebuff="True" Offset="63C" Icon="ICON_BLASTSCOURGE"/>
   </DEBUFF_Abnormalities>
   <MISC_Abnormalities>
-    <Abnormality ID="0" IsDebuff="False" Offset="690" HasConditions="False" Icon="ITEM_DASH"/>
-    <Abnormality ID="1" IsDebuff="False" Offset="694" HasConditions="False" Icon="ICON_STAMINAUP"/>
-    <Abnormality ID="2" IsDebuff="False" Offset="698" HasConditions="False" Icon="ICON_NATURALHEALING" />
-    <Abnormality ID="4" IsDebuff="False" Offset="6A0" HasConditions="True" ConditionOffset="8" IsInfinite="False" Icon="ITEM_MIGHT"/>
-    <Abnormality ID="8" IsDebuff="False" Offset="6B0" HasConditions="True" ConditionOffset="12" IsInfinite="False" Icon="ITEM_ADAMANT"/>
-    <Abnormality ID="13" IsDebuff="False" Offset="6C4" HasConditions="False" Icon="ITEM_ATKPOWDER"/>
-    <Abnormality ID="14" IsDebuff="False" Offset="6C8" HasConditions="False" Icon="ITEM_DEFPOWDER"/>
-    <Abnormality ID="15" IsDebuff="False" Offset="6CC" HasConditions="True" ConditionOffset="8" IsInfinite="True" Icon="ITEM_DEMONDRUG"/>
-    <Abnormality ID="16" IsDebuff="False" Offset="6D0" HasConditions="True" ConditionOffset="8" IsInfinite="True" Icon="ITEM_ARMORSKIN"/>
-    <Abnormality ID="23" IsDebuff="False" Offset="6EC" HasConditions="False" Icon="ICON_HOTRES"/>
-    <Abnormality ID="24" IsDebuff="False" Offset="6F0" HasConditions="False" Icon="ICON_COLDRES"/>
-    <Abnormality ID="26" IsDebuff="False" Offset="6F8" HasConditions="False" Icon="ICON_EXT_HEALTHRECOVERY"/>
-    <Abnormality ID="27" IsDebuff="False" Offset="6FC" HasConditions="False" Icon="ICON_COLDRES"/>
-    <Abnormality ID="34" IsDebuff="False" Offset="718" HasConditions="False" Icon="ICON_ATTACKUP"/>
-    <Abnormality ID="35" IsDebuff="False" Offset="71C" HasConditions="False" Icon="ICON_ICERES+"/>
-    <Abnormality ID="73" IsDebuff="False" Offset="7B4" HasConditions="False" Icon=""/>
+    <Abnormality ID="0" Offset="690" Icon="ITEM_DASH"/>
+    <Abnormality ID="1" Offset="694" Icon="ICON_STAMINAUP"/>
+    <Abnormality ID="2" Offset="698" Icon="ICON_NATURALHEALING"/>
+    <Abnormality ID="4" Offset="6A0" HasConditions="True" ConditionOffset="8" IsInfinite="False" Icon="ITEM_MIGHT"/>
+    <Abnormality ID="8" Offset="6B0" HasConditions="True" ConditionOffset="12" IsInfinite="False" Icon="ITEM_ADAMANT"/>
+    <Abnormality ID="13" Offset="6C4" Icon="ITEM_ATKPOWDER"/>
+    <Abnormality ID="14" Offset="6C8" Icon="ITEM_DEFPOWDER"/>
+    <Abnormality ID="15" Offset="6CC" HasConditions="True" ConditionOffset="8" IsInfinite="True" Icon="ITEM_DEMONDRUG"/>
+    <Abnormality ID="16" Offset="6D0" HasConditions="True" ConditionOffset="8" IsInfinite="True" Icon="ITEM_ARMORSKIN"/>
+    <Abnormality ID="23" Offset="6EC" Icon="ICON_HOTRES"/>
+    <Abnormality ID="24" Offset="6F0" Icon="ICON_COLDRES"/>
+    <Abnormality ID="26" Offset="6F8" Icon="ICON_EXT_HEALTHRECOVERY"/>
+    <Abnormality ID="27" Offset="6FC" Icon="ICON_COLDRES"/>
+    <Abnormality ID="34" Offset="718" Icon="ICON_ATTACKUP"/>
+    <Abnormality ID="35" Offset="71C" Icon="ICON_ICERES+"/>
+    <Abnormality ID="73" Offset="7B4"/>
   </MISC_Abnormalities>
   <GEAR_Abnormalities>
-    <Abnormality ID="0" IsDebuff="False" Offset="6CC" Icon="ICON_DEMONAMMO" IsGearBuff="False"/>
-    <Abnormality ID="1" IsDebuff="False" Offset="6D0" Icon="ICON_ARMORAMMO" IsGearBuff="False"/>
-    <Abnormality ID="2" IsDebuff="False" Offset="764" Icon="ICON_ATTACKUP" IsGearBuff="False"/>
-    <Abnormality ID="3" IsDebuff="False" Offset="76C" Icon="ICON_ARMORSKILL_DARKRED" IsGearBuff="False"/>
-    <Abnormality ID="4" IsDebuff="False" Offset="770" Icon="ICON_AFFINITY" IsGearBuff="False"/>
-    <Abnormality ID="10" IsDebuff="False" Offset="788" Icon="ICON_ARMORSKILL_WHITE" IsGearBuff="False"/>
-    <Abnormality ID="15" IsDebuff="False" Offset="79C" Icon="ICON_ATTACKUP" IsGearBuff="False"/>
-    <Abnormality ID="16" IsDebuff="False" Offset="7A0" Icon="ICON_ARMORSKILL_PURPLE" IsGearBuff="False"/>
-    <Abnormality ID="99" IsDebuff="False" Offset="FC4" Icon="ICON_MANTLE" IsGearBuff="True"/>
-    <Abnormality ID="100" IsDebuff="False" Offset="FC8" Icon="ICON_BOOSTER_RED" IsGearBuff="True"/>
+    <Abnormality ID="0" Offset="6CC" Icon="ICON_DEMONAMMO"/>
+    <Abnormality ID="1" Offset="6D0" Icon="ICON_ARMORAMMO"/>
+    <Abnormality ID="2" Offset="764" Icon="ICON_ATTACKUP"/>
+    <Abnormality ID="3" Offset="76C" Icon="ICON_ARMORSKILL_DARKRED"/>
+    <Abnormality ID="4" Offset="770" Icon="ICON_AFFINITY"/>
+    <Abnormality ID="10" Offset="788" Icon="ICON_ARMORSKILL_WHITE"/>
+    <Abnormality ID="15" Offset="79C" Icon="ICON_ATTACKUP"/>
+    <Abnormality ID="16" Offset="7A0" Icon="ICON_ARMORSKILL_PURPLE"/>
+    <Abnormality ID="99" Offset="FC4" Icon="ICON_MANTLE" IsGearBuff="True"/>
+    <Abnormality ID="100" Offset="FC8" Icon="ICON_BOOSTER_RED" IsGearBuff="True"/>
   </GEAR_Abnormalities>
 </Abnormalities>

--- a/HunterPie/HunterPie.csproj
+++ b/HunterPie/HunterPie.csproj
@@ -129,6 +129,7 @@
     </ApplicationDefinition>
     <Compile Include="Core\Integrations\Honey\Honey.cs" />
     <Compile Include="Core\KeyboardHook.cs" />
+    <Compile Include="Core\LPlayer\AbnormalityInfo.cs" />
     <Compile Include="Core\Monster\Ailment.cs" />
     <Compile Include="Core\Monster\MonsterData.cs" />
     <Compile Include="Core\Monster\Part.cs" />


### PR DESCRIPTION
### XML for Player Abnormalities is parsed only once at the beginning to make it faster and simpler.

I also cleaned up attributes and made some of them optional:

- IsDebuff defaults to False
- IsGear defaults to False
- IsInfinite  defaults to False
- HasConditions defaults to False
- ConditionOffset defaults to 0
- Stack defaults to 0
- IconName defaults to ICON_MISSING

As discussed, the style is changed.
We'll probably do something similar with monster data.
I haven't changed memory reading logic, but it can be made faster by reading whole block of player data at once and using it later, to reduce the number of ReadProcessMemory calls and allocations.