### PR TITLE
Add support for part breaks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,184 @@
+# editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[project.json]
+indent_size = 2
+
+# C# files
+[*.cs]
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+
+# avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Types: use keywords instead of BCL types, and permit var only when the type is clear
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_elsewhere = false:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds   = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# static fields should have no prefix
+dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_have_prefix.style    = static_prefix_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
+dotnet_naming_style.static_prefix_style.required_prefix =
+dotnet_naming_style.static_prefix_style.capitalization = camel_case
+
+# internal and private fields should be camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+dotnet_naming_style.camel_case_underscore_style.required_prefix =
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
+
+# Code style defaults
+csharp_using_directive_placement = outside_namespace:suggestion
+dotnet_sort_system_directives_first = true
+csharp_prefer_braces = true:refactoring
+csharp_preserve_single_line_blocks = true:none
+csharp_preserve_single_line_statements = false:none
+csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_simple_using_statement = false:none
+csharp_style_prefer_switch_expression = true:suggestion
+
+# Code quality
+dotnet_style_readonly_field = true:suggestion
+dotnet_code_quality_unused_parameters = non_public:suggestion
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:refactoring
+dotnet_style_prefer_conditional_expression_over_return = true:refactoring
+csharp_prefer_simple_default_expression = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = true:refactoring
+csharp_style_expression_bodied_constructors = true:refactoring
+csharp_style_expression_bodied_operators = true:refactoring
+csharp_style_expression_bodied_properties = true:refactoring
+csharp_style_expression_bodied_indexers = true:refactoring
+csharp_style_expression_bodied_accessors = true:refactoring
+csharp_style_expression_bodied_lambdas = true:refactoring
+csharp_style_expression_bodied_local_functions = true:refactoring
+
+# Pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# Null checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Other features
+csharp_style_prefer_index_operator = false:none
+csharp_style_prefer_range_operator = false:none
+csharp_style_pattern_local_over_anonymous_function = false:none
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Analyzers
+dotnet_code_quality.ca1802.api_surface = private, internal
+
+# C++ Files
+[*.{cpp,h,in}]
+curly_bracket_next_line = true
+indent_brace_style = Allman
+
+# Xml project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
+indent_size = 2
+
+# Xml build files
+[*.builds]
+indent_size = 2
+
+# Xml files
+[*.{xml,stylecop,resx,ruleset}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+end_of_line = lf
+[*.{cmd, bat}]
+end_of_line = crlf

--- a/HunterPie/Core/Args.cs
+++ b/HunterPie/Core/Args.cs
@@ -23,9 +23,9 @@ namespace HunterPie.Core {
     public class DaysLeftEventArgs : EventArgs {
         public byte Days;
         // Generic name
-        // Argosy 
+        // Argosy
         // Tailraiders means
-        public bool Modifier; 
+        public bool Modifier;
 
         public DaysLeftEventArgs(byte Days, bool Modifier = false) {
             this.Days = Days;
@@ -36,7 +36,7 @@ namespace HunterPie.Core {
     public class KeyboardInputEventArgs : EventArgs {
         public int Key { get; private set; }
         public KeyboardHookHelper.KeyboardMessage KeyMessage { get; private set; }
-        
+
         public KeyboardInputEventArgs(int KeyCode, KeyboardHookHelper.KeyboardMessage Message) {
             this.Key = KeyCode;
             this.KeyMessage = Message;
@@ -102,21 +102,18 @@ namespace HunterPie.Core {
     }
 
 
-    public class MonsterPartEventArgs : EventArgs {
-        public string Name;
-        public int ID;
-        public float Health;
-        public float TotalHealth;
-        public byte BrokenCounter;
-
-        public MonsterPartEventArgs(Part mPart) {
-            this.Name = mPart.Name;
-            this.ID = mPart.Id;
-            this.Health = mPart.Health;
-            this.TotalHealth = mPart.TotalHealth;
-            this.BrokenCounter = mPart.BrokenCounter;
+    public class MonsterPartEventArgs : EventArgs
+    {
+        public MonsterPartEventArgs(Part part)
+        {
+            Health = part.Health;
+            TotalHealth = part.TotalHealth;
+            BrokenCounter = part.BrokenCounter;
         }
 
+        public float Health { get; }
+        public float TotalHealth { get; }
+        public byte BrokenCounter { get; }
     }
 
     public class MonsterSpawnEventArgs : EventArgs {
@@ -138,7 +135,7 @@ namespace HunterPie.Core {
             this.Weaknesses = m.Weaknesses;
         }
     }
-    
+
     public class MonsterUpdateEventArgs : EventArgs {
         public float CurrentHP;
         public float TotalHP;

--- a/HunterPie/Core/Monsters/MonsterData.cs
+++ b/HunterPie/Core/Monsters/MonsterData.cs
@@ -99,9 +99,15 @@ namespace HunterPie.Core {
                     IsRemovable = bool.Parse(partData.Attributes["IsRemovable"]?.Value ?? "false"),
                     GroupId = partData.Attributes["Group"]?.Value ?? "MISC"
                 };
+
+                XmlNodeList breaks = partData.SelectNodes("Break");
+                pInfo.BreakThresholds = breaks != null
+                    ? breaks.Cast<XmlNode>().Select(b => int.Parse(b.Attributes["Threshold"].Value)).ToArray()
+                    : Array.Empty<int>();
+
                 parts.Add(pInfo);
             }
-            
+
             return parts.ToArray();
         }
 

--- a/HunterPie/Core/Monsters/MonsterInfo.cs
+++ b/HunterPie/Core/Monsters/MonsterInfo.cs
@@ -17,10 +17,11 @@
         public string Id;
         public bool IsRemovable;
         public string GroupId;
+        public int[] BreakThresholds;
     }
     #endregion
 
-    public class MonsterInfo 
+    public class MonsterInfo
     {
         // Basic info
         public string Em { get; set; }

--- a/HunterPie/Core/Monsters/Part.cs
+++ b/HunterPie/Core/Monsters/Part.cs
@@ -1,72 +1,101 @@
-﻿using System;
+﻿using HunterPie.Core.Monsters;
 
-namespace HunterPie.Core {
-    public class Part {
-        private float _Health { get; set; }
-        private float _TotalHealth { get; set; }
-        private byte _BrokenCounter { get; set; }
-        private int MonsterId { get; set; }
-        public Int64 PartAddress { get; set; } // So we don't need to re-scan the address everytime
-        
+namespace HunterPie.Core
+{
+    public class Part
+    {
+        private readonly MonsterInfo monsterInfo;
+        private readonly PartInfo partInfo;
+        private readonly int id; // Part index
 
-        public int Id { get; set; } // Part index
-        public string Name {
-            get { return GStrings.GetMonsterPartByID(MonsterData.MonstersInfo[MonsterId].Parts[Id].Id); }
+        private float health;
+        private float totalHealth;
+        private byte brokenCounter;
+
+        public Part(MonsterInfo monsterInfo, PartInfo partInfo, int index)
+        {
+            this.monsterInfo = monsterInfo;
+            this.partInfo = partInfo;
+            id = index;
         }
-        public byte BrokenCounter {
-            get { return _BrokenCounter; }
-            set {
-                if (value != _BrokenCounter) {
-                    this._BrokenCounter = value;
-                    _OnBrokenCounterChange();
+
+        public long PartAddress { get; set; } // So we don't need to re-scan the address everytime
+
+        public string Name => GStrings.GetMonsterPartByID(partInfo.Id);
+
+        public int[] BreakThresholds => partInfo.BreakThresholds;
+
+        public byte BrokenCounter
+        {
+            get => brokenCounter;
+            set
+            {
+                if (value != brokenCounter)
+                {
+                    brokenCounter = value;
+                    NotifyBrokenCounterChanged();
                 }
             }
         }
-        public float Health {
-            get { return _Health; }
-            set {
-                if (value != _Health) {
-                    this._Health = value;
-                    _OnHealthChange();
+
+        public float Health
+        {
+            get => health;
+            set
+            {
+                if (value != health)
+                {
+                    health = value;
+                    NotifyHealthChanged();
                 }
             }
         }
-        public float TotalHealth {
-            get { return _TotalHealth; }
-            set {
-                if (value != _TotalHealth) {
-                    this._TotalHealth = value;
+
+        public float TotalHealth
+        {
+            get => totalHealth;
+            set
+            {
+                if (value != totalHealth)
+                {
+                    totalHealth = value;
                 }
             }
         }
+
         public bool IsRemovable { get; set; }
         public string Group { get; set; }
 
         #region Events
+
         public delegate void MonsterPartEvents(object source, MonsterPartEventArgs args);
+
         public event MonsterPartEvents OnHealthChange;
         public event MonsterPartEvents OnBrokenCounterChange;
 
-        protected virtual void _OnHealthChange() {
+        protected virtual void NotifyHealthChanged()
+        {
             OnHealthChange?.Invoke(this, new MonsterPartEventArgs(this));
         }
 
-        protected virtual void _OnBrokenCounterChange() {
+        protected virtual void NotifyBrokenCounterChanged()
+        {
             OnBrokenCounterChange?.Invoke(this, new MonsterPartEventArgs(this));
+            Logger.Debugger.Debug($"Broken {GStrings.GetMonsterNameByID(monsterInfo.Em)} ({monsterInfo.Id}) part {Name} ({id}), {TotalHealth} hp for {brokenCounter} time");
         }
+
         #endregion
 
-        public void SetPartInfo(int monsterId, int id, byte Counter, float Health, float TotalHealth) {
-            this.MonsterId = monsterId;
-            this.Id = id;
-            this.TotalHealth = TotalHealth;
-            this.BrokenCounter = Counter;
-            this.Health = Health;
+        public void SetPartInfo(byte breakCounter, float health, float totalHealth)
+        {
+            TotalHealth = totalHealth;
+            BrokenCounter = breakCounter;
+            Health = health;
         }
 
-        public override string ToString() {
-            return $"Name: {this.Name} | ID: {this.Id} | HP: {this.Health}/{this.TotalHealth} | Counter: {this.BrokenCounter}";
+        public override string ToString()
+        {
+            return $"Name: {Name} | ID: {id} | HP: {Health}/{TotalHealth} | Counter: {BrokenCounter}";
         }
-
     }
 }

--- a/HunterPie/GUI/Widgets/Monster Widget/Parts/MonsterPart.xaml
+++ b/HunterPie/GUI/Widgets/Monster Widget/Parts/MonsterPart.xaml
@@ -8,7 +8,7 @@
              mc:Ignorable="d" 
              d:DesignHeight="30" d:DesignWidth="260" SnapsToDevicePixels="True">
     <Grid>
-        <Custom:MinimalHealthBar Color="{StaticResource OVERLAY_MONSTER_PART_BAR_COLOR}" x:Name="PartHealth" Margin="30,13,5,0" RenderTransformOrigin="0.5,0.5" Height="3" VerticalAlignment="Top" >
+        <Custom:MinimalHealthBar Color="{StaticResource OVERLAY_MONSTER_PART_BAR_COLOR}" x:Name="PartHealth" Margin="32,13,5,0" RenderTransformOrigin="0.5,0.5" Height="3" VerticalAlignment="Top" >
             <Custom:MinimalHealthBar.RenderTransform>
                 <TransformGroup>
                     <ScaleTransform/>
@@ -19,17 +19,8 @@
             </Custom:MinimalHealthBar.RenderTransform>
         </Custom:MinimalHealthBar>
         <TextBlock Style="{StaticResource OVERLAY_MONSTER_PART_NAME_TEXT_STYLE}" x:Name="PartName" Text="Monster Part" Height="22" VerticalAlignment="Top" TextTrimming="CharacterEllipsis" SnapsToDevicePixels="True"/>
-        <Rectangle Height="17" VerticalAlignment="Top" Margin="13,6,0,0" HorizontalAlignment="Left" Width="17" RenderTransformOrigin="0.5,0.5" Style="{StaticResource OVERLAY_MONSTER_PART_COUNTER_BACKGROUND_STYLE}">
-            <Rectangle.RenderTransform>
-                <TransformGroup>
-                    <ScaleTransform/>
-                    <SkewTransform/>
-                    <RotateTransform Angle="45"/>
-                    <TranslateTransform/>
-                </TransformGroup>
-            </Rectangle.RenderTransform>
-        </Rectangle>
-        <TextBlock Style="{StaticResource OVERLAY_MONSTER_PART_COUNTER_TEXT_STYLE}" x:Name="PartBrokenCounter" Text="0" Height="23" VerticalAlignment="Top" TextOptions.TextHintingMode="Fixed" FontSize="12" Padding="0,2,0,0" Margin="10,3,0,0" TextAlignment="Center" HorizontalAlignment="Left" Width="23"/>
+        <Polygon Points="0, 15 14, 1 21, 1 35, 15 21, 29 14, 29" Style="{StaticResource OVERLAY_MONSTER_PART_COUNTER_BACKGROUND_STYLE}" />
+        <TextBlock Style="{StaticResource OVERLAY_MONSTER_PART_COUNTER_TEXT_STYLE}" x:Name="PartBrokenCounter" Text="0/2" Height="24" VerticalAlignment="Top" TextOptions.TextHintingMode="Fixed" FontSize="12" Padding="0,3,0,0" Margin="2,3,0,0" TextAlignment="Center" HorizontalAlignment="Left" Width="31"/>
 
         <TextBlock Style="{StaticResource OVERLAY_MONSTER_PART_NAME_TEXT_STYLE}" x:Name="PartHealthText" Text="1600/1600" Height="15" VerticalAlignment="Top" Margin="29,15,0,0" TextOptions.TextHintingMode="Fixed" FontSize="11" TextAlignment="Center" SnapsToDevicePixels="True"/>
     </Grid>

--- a/HunterPie/GUIControls/Custom Controls/MinimalHealthBar.xaml.cs
+++ b/HunterPie/GUIControls/Custom Controls/MinimalHealthBar.xaml.cs
@@ -1,43 +1,45 @@
-﻿using System.Windows.Controls;
+﻿using System;
+using System.Windows.Controls;
 using System.Windows.Media;
 
 namespace HunterPie.GUIControls.Custom_Controls {
     /// <summary>
     /// Interaction logic for MinimalHealthBar.xaml
     /// </summary>
-    public partial class MinimalHealthBar : UserControl {
-        private double _MaxHealth { get; set; }
-        private double _Health { get; set; }
+    public partial class MinimalHealthBar : UserControl
+    {
+        private double health;
+
         public double MaxSize { get; set; }
 
-        public double MaxHealth {
-            get { return _MaxHealth; }
-            set {
-                _MaxHealth = value;
+        public double MaxHealth { get; set; }
+
+        public double Health
+        {
+            get => health;
+            set
+            {
+                health = value;
+                HealthBar.Width = Math.Max(MaxSize * (value / MaxHealth), 0);
             }
         }
 
-        public double Health {
-            get { return _Health; }
-            set {
-                _Health = value;
-                HealthBar.Width = MaxSize * (value / MaxHealth) > 0 ? MaxSize * (value / MaxHealth) : 0;
-            }
+        public Brush Color
+        {
+            get => HealthBar.Fill;
+            set => HealthBar.Fill = value;
         }
 
-        public Brush Color {
-            get { return HealthBar.Fill; }
-            set { HealthBar.Fill = value; }
-        }
-
-        public MinimalHealthBar() {
+        public MinimalHealthBar()
+        {
             InitializeComponent();
         }
 
-        public void UpdateBar(float hp, float max_hp) {
+        public void UpdateBar(float hp, float maxHp)
+        {
             HealthBarBackground.Width = MaxSize;
-            this.MaxHealth = max_hp;
-            this.Health = hp;
+            MaxHealth = maxHp;
+            Health = hp;
         }
     }
 }

--- a/HunterPie/HunterPie.Resources/Data/MonsterData.xml
+++ b/HunterPie/HunterPie.Resources/Data/MonsterData.xml
@@ -1073,24 +1073,50 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="18">
-      <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_REMOVABLE_HORNS_2" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HORNS" Group="HORN"/>
+      <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_REMOVABLE_HORNS_2" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HORNS" Group="HORN">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_CHEST" Group="CHEST"/>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
       <Part Name="MONSTER_PART_LLIMBS" Group="LIMB"/>
       <Part Name="MONSTER_PART_RLIMBS" Group="LIMB"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
-      <Part Name="MONSTER_PART_HORNS_GOLD" Group="HORN"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HORNS_GOLD" Group="HORN">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_MANE_GOLD" Group="MANE"/>
-      <Part Name="MONSTER_PART_LCHEST_GOLD" Group="CHEST"/>
-      <Part Name="MONSTER_PART_RCHEST_GOLD" Group="CHEST"/>
-      <Part Name="MONSTER_PART_LARM_GOLD" Group="ARM"/>
-      <Part Name="MONSTER_PART_RARM_GOLD" Group="ARM"/>
-      <Part Name="MONSTER_PART_LLEG_GOLD" Group="LEG"/>
-      <Part Name="MONSTER_PART_RLEG_GOLD" Group="LEG"/>
-      <Part Name="MONSTER_PART_LTAIL_GOLD" Group="TAIL"/>
-      <Part Name="MONSTER_PART_RTAIL_GOLD" Group="TAIL"/>
+      <Part Name="MONSTER_PART_LCHEST_GOLD" Group="CHEST">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RCHEST_GOLD" Group="CHEST">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LARM_GOLD" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RARM_GOLD" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LLEG_GOLD" Group="LEG">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RLEG_GOLD" Group="LEG">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LTAIL_GOLD" Group="TAIL">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RTAIL_GOLD" Group="TAIL">
+        <Break Threshold="1"/>
+      </Part>
     </Parts>
   </Monster>
   <Monster ID="em118_00" Capture="30" GameID="39"> <!-- Bazelgeuse -->

--- a/HunterPie/HunterPie.Resources/Data/MonsterData.xml
+++ b/HunterPie/HunterPie.Resources/Data/MonsterData.xml
@@ -35,13 +35,13 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING"/>
+      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em001_01" Capture="25"  GameID="10"> <!-- Pink Rathian -->
@@ -52,13 +52,13 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING"/>
+      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em001_02" Capture="10"  GameID="88"> <!-- Gold Rathian -->
@@ -68,14 +68,24 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em002_00" Capture="20"  GameID="1"> <!-- Rathalos -->
@@ -86,13 +96,13 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING"/>
+      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em002_01" Capture="15"  GameID="11"> <!-- Azure Rathalos -->
@@ -103,13 +113,13 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING"/>
+      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em002_02" Capture="10"  GameID="89"> <!-- Silver Rathalos -->
@@ -119,14 +129,24 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em007_00" Capture="20"  GameID="12"> <!-- Diablos -->
@@ -138,13 +158,13 @@
     <Parts Max="9">
       <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True"/>
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING"/>
+      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em007_01" Capture="15"  GameID="13"> <!-- Black Diablos -->
@@ -156,13 +176,13 @@
     <Parts Max="9">
       <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True"/>
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING"/>
+      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em011_00" Capture="0"  GameID="14"> <!-- Kirin -->
@@ -172,9 +192,9 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="3">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
     </Parts>
   </Monster>
   <Monster ID="em018_00" Capture="20"  GameID="90"> <!-- Yian Garuga -->
@@ -185,13 +205,13 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING"/>
+      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em018_05" Capture="15"  GameID="99"> <!-- Scarred Yian Garuga -->
@@ -202,13 +222,13 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING"/>
+      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em023_00" Capture="15"  GameID="91"> <!-- Rajang -->
@@ -220,13 +240,13 @@
     <Parts Max="11">
       <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True"/>
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
       <Part Name="MONSTER_PART_REMOVABLE_HORNS_2" IsRemovable="True"/>
       <Part Name="MONSTER_PART_UNKNOWN" IsRemovable="True"/>
     </Parts>
@@ -240,13 +260,13 @@
     <Parts Max="11">
       <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
       <Part Name="MONSTER_PART_REMOVABLE_HORNS_2" IsRemovable="True"/>
       <Part Name="MONSTER_PART_UNKNOWN" IsRemovable="True"/>
     </Parts>
@@ -259,12 +279,12 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLIMBS" Group="LIMB" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLIMBS" Group="LIMB" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_WINGS" Group="WING" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_LLIMBS" Group="LIMB"/>
+      <Part Name="MONSTER_PART_RLIMBS" Group="LIMB"/>
+      <Part Name="MONSTER_PART_WINGS" Group="WING"/>
     </Parts>
   </Monster>
   <Monster ID="em026_00" Capture="0"  GameID="17"> <!-- Lunastra -->
@@ -275,12 +295,12 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LIMBS" Group="LIMB" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LIMBS" Group="LIMB"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING"/>
+      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em027_00" Capture="0"  GameID="18"> <!-- Teostra -->
@@ -291,12 +311,12 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_WINGS" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
+      <Part Name="MONSTER_PART_WINGS" Group="WING"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em032_00" Capture="20"  GameID="61"> <!-- Tigrex -->
@@ -307,13 +327,13 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em032_01" Capture="15"  GameID="93"> <!-- Brute Tigrex -->
@@ -324,13 +344,13 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em036_00" Capture="20"  GameID="19"> <!-- Lavasioth -->
@@ -340,12 +360,12 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="6">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ABDOMEN" Group="ABDOMEN" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_ABDOMEN" Group="ABDOMEN"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em037_00" Capture="20"  GameID="62"> <!-- Nargacuga -->
@@ -356,13 +376,13 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em042_00" Capture="20" GameID="63"> <!-- Barioth -->
@@ -373,13 +393,13 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em043_00" Capture="20"  GameID="20"> <!-- Deviljho -->
@@ -390,14 +410,14 @@
     <Crown Mini="0.9" Silver="1.10" Gold="1.20"/>
     <Parts Max="9">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_CHEST" Group="CHEST" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_REAR" Group="REAR" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_CHEST" Group="CHEST"/>
+      <Part Name="MONSTER_PART_REAR" Group="REAR"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em043_05" Capture="10"  GameID="64"> <!-- Savage Deviljho -->
@@ -407,15 +427,21 @@
     </Weaknesses>
     <Crown Mini="0.99" Silver="1.14" Gold="1.20"/>
     <Parts Max="9">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_CHEST" Group="CHEST" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_REAR" Group="REAR" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_CHEST" Group="CHEST">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_REAR" Group="REAR"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em044_00" Capture="25"  GameID="21"> <!-- Barroth -->
@@ -427,18 +453,18 @@
     <Parts Max="14">
       <Part Name="MONSTER_PART_REMOVABLE_HEAD" IsRemovable="True"/>
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_HEAD_MUD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY_MUD" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS_MUD" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG_MUD" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG_MUD" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL_MUD" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_HEAD_MUD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_BODY_MUD" Group="BODY"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_ARMS_MUD" Group="ARM"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_LLEG_MUD" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG_MUD" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_TAIL_MUD" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em045_00" Capture="20"  GameID="22"> <!-- Uragaan -->
@@ -449,13 +475,13 @@
     <Crown Mini="0.9" Silver="1.10" Gold="1.20"/>
     <Parts Max="8">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_JAW" Group="JAW" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_JAW" Group="JAW"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em057_00" Capture="20"  GameID="94"> <!-- Zinogre -->
@@ -465,13 +491,22 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BACK" Group="BACK" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+        <Break Threshold="4"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_BACK" Group="BACK">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em057_01" Capture="20"  GameID="95"> <!-- Stygian Zinogre -->
@@ -481,13 +516,22 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BACK" Group="BACK" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+        <Break Threshold="4"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_BACK" Group="BACK">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM">
+        <Break Threshold="3"/>
+      </Part>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em063_00" Capture="20"  GameID="65"> <!-- Brachydios -->
@@ -498,13 +542,13 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em063_05" Capture="0"  GameID="96"> <!-- Raging Brachydios -->
@@ -515,15 +559,15 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="10">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BACK" Group="BACK" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_BACK" Group="BACK"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em080_00" Capture="20"  GameID="66"> <!-- Glavenus -->
@@ -534,13 +578,13 @@
     <Crown Mini="0.9" Silver="1.10" Gold="1.20"/>
     <Parts Max="8">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_FIN" Group="FIN" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_FIN" Group="FIN"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em080_01" Capture="20"  GameID="67"> <!-- Acidic Glavenus -->
@@ -551,13 +595,13 @@
     <Crown Mini="0.9" Silver="1.10" Gold="1.20"/>
     <Parts Max="8">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_FIN" Group="FIN" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_FIN" Group="FIN"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em100_00" Capture="25"  GameID="0"> <!-- Anjanath -->
@@ -568,11 +612,11 @@
     <Crown Mini="0.9" Silver="1.10" Gold="1.20"/>
     <Parts Max="6">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em100_01" Capture="15"  GameID="68"> <!-- Fulgur Anjanath -->
@@ -583,11 +627,11 @@
     <Crown Mini="0.9" Silver="1.10" Gold="1.20"/>
     <Parts Max="6">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em101_00" Capture="30"  GameID="7"> <!-- Great Jagras -->
@@ -597,12 +641,12 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="6">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ABDOMEN" Group="ABDOMEN" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_ABDOMEN" Group="ABDOMEN"/>
     </Parts>
   </Monster>
   <Monster ID="em102_00" Capture="25"  GameID="24"> <!-- Pukei-Pukei -->
@@ -614,13 +658,13 @@
     <Parts Max="9">
       <Part Name="MONSTER_PART_REMOVABLE_HEAD" IsRemovable="True"/>
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING"/>
+      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em102_01" Capture="25"  GameID="69"> <!-- Coral Pukei-Pukei -->
@@ -631,13 +675,13 @@
     <Crown Mini="0.9" Silver="1.10" Gold="1.20"/>
     <Parts Max="8">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING"/>
+      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em103_00" Capture="0"  GameID="25"> <!-- Nergigante -->
@@ -649,16 +693,16 @@
     <Parts Max="12">
       <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True"/>
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HORNS" Group="HORN" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HORNS" Group="HORN"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING"/>
+      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em103_05" Capture="0"  GameID="70"> <!-- Ruiner Nergigante -->
@@ -670,16 +714,16 @@
     <Parts Max="12">
       <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True"/>
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HORNS" Group="HORN" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HORNS" Group="HORN"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING"/>
+      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em104_00" Capture="0"  GameID="97"> <!-- Safi'jiiva -->
@@ -689,19 +733,40 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="13">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ABDOMEN" Group="ABDOMEN" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BACK" Group="BACK" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_NECK" Group="NECK" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="5"/>
+        <Break Threshold="10"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_ABDOMEN" Group="ABDOMEN">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_BACK" Group="BACK">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_NECK" Group="NECK"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM">
+        <Break Threshold="7"/>
+      </Part>
+      <Part Name="MONSTER_PART_RARM" Group="ARM">
+        <Break Threshold="7"/>
+      </Part>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG">
+        <Break Threshold="5"/>
+      </Part>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG">
+        <Break Threshold="5"/>
+      </Part>
+      <Part Name="MONSTER_PART_LWING" Group="WING">
+        <Break Threshold="3"/>
+      </Part>
+      <Part Name="MONSTER_PART_RWING" Group="WING">
+        <Break Threshold="3"/>
+      </Part>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em105_00" Capture="0"  GameID="26"> <!-- Xeno'jiiva -->
@@ -712,16 +777,16 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="11">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_NECK" Group="NECK"  IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BACK" Group="BACK" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_CHEST" Group="CHEST" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LHAND" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RHAND" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LFOOT" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RFOOT" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_WINGS" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_NECK" Group="NECK" />
+      <Part Name="MONSTER_PART_BACK" Group="BACK"/>
+      <Part Name="MONSTER_PART_CHEST" Group="CHEST"/>
+      <Part Name="MONSTER_PART_LHAND" Group="ARM"/>
+      <Part Name="MONSTER_PART_RHAND" Group="ARM"/>
+      <Part Name="MONSTER_PART_LFOOT" Group="LEG"/>
+      <Part Name="MONSTER_PART_RFOOT" Group="LEG"/>
+      <Part Name="MONSTER_PART_WINGS" Group="WING"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em106_00" Capture="0"  GameID="4"> <!-- Zorah Magdaros -->
@@ -731,21 +796,21 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="15">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_CHEST" Group="CHEST" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_SHELL" Group="SHELL" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_EXHAUST_ORGAN_CENTRAL" Group="ORGAN" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_EXHAUST_ORGAN_HEAD" Group="ORGAN" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_EXHAUST_ORGAN_CRATER" Group="ORGAN" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_EXHAUST_ORGAN_REAR" Group="ORGAN" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_WEAK_LSHELL" Group="SHELL" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_WEAK_RSHELL" Group="SHELL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_CHEST" Group="CHEST"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_SHELL" Group="SHELL"/>
+      <Part Name="MONSTER_PART_EXHAUST_ORGAN_CENTRAL" Group="ORGAN"/>
+      <Part Name="MONSTER_PART_EXHAUST_ORGAN_HEAD" Group="ORGAN"/>
+      <Part Name="MONSTER_PART_EXHAUST_ORGAN_CRATER" Group="ORGAN"/>
+      <Part Name="MONSTER_PART_EXHAUST_ORGAN_REAR" Group="ORGAN"/>
+      <Part Name="MONSTER_PART_WEAK_LSHELL" Group="SHELL"/>
+      <Part Name="MONSTER_PART_WEAK_RSHELL" Group="SHELL"/>
     </Parts>
   </Monster>
   <Monster ID="em107_00" Capture="30"  GameID="27"> <!-- Kulu-Ya-Ku -->
@@ -755,11 +820,11 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="5">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ROCK" Group="MISC" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_ROCK" Group="MISC"/>
     </Parts>
   </Monster>
   <Monster ID="em108_00" Capture="25"  GameID="29"> <!-- Jyuratodus -->
@@ -769,16 +834,16 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="10">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_HEAD_MUD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY_MUD" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG_MUD" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG_MUD" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL_MUD" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_HEAD_MUD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY_MUD" Group="BODY"/>
+      <Part Name="MONSTER_PART_LLEG_MUD" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG_MUD" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL_MUD" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em109_00" Capture="25"  GameID="30"> <!-- Tobi-Kadachi -->
@@ -788,12 +853,12 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.10" Gold="1.20"/>
     <Parts Max="6">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_MANE" Group="MANE" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_MANE" Group="MANE"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em109_01" Capture="25" GameID="71"> <!-- Viper Tobi-Kadachi -->
@@ -803,12 +868,12 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.10" Gold="1.20"/>
     <Parts Max="6">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_MANE" Group="MANE" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_MANE" Group="MANE"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em110_00" Capture="25" GameID="31"> <!-- Paolumu -->
@@ -819,14 +884,14 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="9">
       <Part Name="MONSTER_PART_REMOVABLE_BALLOON" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BALLOON" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BALLOON" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING"/>
+      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em110_01" Capture="25" GameID="72"> <!-- Nightshade Paolumu -->
@@ -837,14 +902,14 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="9">
       <Part Name="MONSTER_PART_REMOVABLE_BALLOON" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BALLOON" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BALLOON" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING"/>
+      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em111_00" Capture="20" GameID="32"> <!-- Legiana -->
@@ -854,13 +919,13 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING"/>
+      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em111_05" Capture="15" GameID="73"> <!-- Shrieking Legiana -->
@@ -870,12 +935,12 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING"/>
+      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
 	  <Part Name="MONSTER_PART_UNKNOWN" Group="HEAD" IsRemovable="True"/>
     </Parts>
   </Monster>
@@ -887,11 +952,11 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="6">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em113_00" Capture="20" GameID="34"> <!-- Odogaron -->
@@ -902,11 +967,11 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
 	  <Part Name="MONSTER_PART_UNKNOWN" IsRemovable="True"/>
     </Parts>
   </Monster>
@@ -917,11 +982,11 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
 	  <Part Name="MONSTER_PART_UNKNOWN" IsRemovable="True"/>
 	  <Part Name="MONSTER_PART_REMOVABLE_HEAD" IsRemovable="True"/>
 	  <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
@@ -935,15 +1000,15 @@
     <Crown Mini="0.9" Silver="1.10" Gold="1.20"/>
     <Parts Max="10">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_JAW" Group="JAW" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BACK" Group="BACK" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LBONE" Group="BONE" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RBONE" Group="BONE" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_JAW" Group="JAW"/>
+      <Part Name="MONSTER_PART_BACK" Group="BACK"/>
+      <Part Name="MONSTER_PART_LBONE" Group="BONE"/>
+      <Part Name="MONSTER_PART_RBONE" Group="BONE"/>
     </Parts>
   </Monster>
   <Monster ID="em115_00" Capture="0"  GameID="36"> <!-- Vaal Hazak -->
@@ -953,15 +1018,15 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="11">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BACK" Group="BACK" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_CHEST" Group="CHEST" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_WINGS" Group="WING" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BACK" Group="BACK"/>
+      <Part Name="MONSTER_PART_CHEST" Group="CHEST"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_WINGS" Group="WING"/>
       <Part Name="MONSTER_PART_UNKNOWN" Group="MISC" IsRemovable="True"/>
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
     </Parts>
@@ -973,15 +1038,15 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="11">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BACK" Group="BACK" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_CHEST" Group="CHEST" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_WINGS" Group="WING" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BACK" Group="BACK"/>
+      <Part Name="MONSTER_PART_CHEST" Group="CHEST"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_WINGS" Group="WING"/>
 	  <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
 	  <Part Name="MONSTER_PART_UNKNOWN" Group="MISC" IsRemovable="True"/>
     </Parts>
@@ -994,11 +1059,11 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="6">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em117_00" Capture="0" GameID="38"> <!-- Kulve Taroth -->
@@ -1010,22 +1075,22 @@
     <Parts Max="18">
       <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True"/>
       <Part Name="MONSTER_PART_REMOVABLE_HORNS_2" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HORNS" Group="HORN" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_CHEST" Group="CHEST" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLIMBS" Group="LIMB" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLIMBS" Group="LIMB" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_HORNS_GOLD" Group="HORN" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_MANE_GOLD" Group="MANE" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LCHEST_GOLD" Group="CHEST" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RCHEST_GOLD" Group="CHEST" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LARM_GOLD" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RARM_GOLD" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG_GOLD" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG_GOLD" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LTAIL_GOLD" Group="TAIL" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RTAIL_GOLD" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HORNS" Group="HORN"/>
+      <Part Name="MONSTER_PART_CHEST" Group="CHEST"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LLIMBS" Group="LIMB"/>
+      <Part Name="MONSTER_PART_RLIMBS" Group="LIMB"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_HORNS_GOLD" Group="HORN"/>
+      <Part Name="MONSTER_PART_MANE_GOLD" Group="MANE"/>
+      <Part Name="MONSTER_PART_LCHEST_GOLD" Group="CHEST"/>
+      <Part Name="MONSTER_PART_RCHEST_GOLD" Group="CHEST"/>
+      <Part Name="MONSTER_PART_LARM_GOLD" Group="ARM"/>
+      <Part Name="MONSTER_PART_RARM_GOLD" Group="ARM"/>
+      <Part Name="MONSTER_PART_LLEG_GOLD" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG_GOLD" Group="LEG"/>
+      <Part Name="MONSTER_PART_LTAIL_GOLD" Group="TAIL"/>
+      <Part Name="MONSTER_PART_RTAIL_GOLD" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em118_00" Capture="30" GameID="39"> <!-- Bazelgeuse -->
@@ -1036,12 +1101,12 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING"/>
+      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em118_05" Capture="10" GameID="76"> <!-- Seething Bazelgeuse -->
@@ -1052,12 +1117,12 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING"/>
+      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em120_00" Capture="30" GameID="28"> <!-- TziTzi-Ya-Ku -->
@@ -1067,11 +1132,11 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="5">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_UNKNOWN" Group="MISC" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_UNKNOWN" Group="MISC"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em121_00" Capture="0" GameID="15"> <!-- Behemoth -->
@@ -1082,14 +1147,14 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="9">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HORNS" Group="HORN" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HORNS" Group="HORN"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em122_00" Capture="25" GameID="77"> <!-- Beotodus -->
@@ -1099,13 +1164,13 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_HEAD_SNOW" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY_SNOW" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL_SNOW" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_HEAD_SNOW" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_BODY_SNOW" Group="BODY"/>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_TAIL_SNOW" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em123_00" Capture="25" GameID="78"> <!-- Banbaro -->
@@ -1117,11 +1182,11 @@
     <Parts Max="7">
       <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True"/>
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HORNS" Group="HORN" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HORNS" Group="HORN"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em124_00" Capture="0" GameID="79"> <!-- Velkhana -->
@@ -1132,18 +1197,18 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="13">
       <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_HEAD_ICE" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY_ICE" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_WINGS" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_WINGS_ICE" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS_ICE" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS_ICE" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL_ICE" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_HEAD_ICE" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_BODY_ICE" Group="BODY"/>
+      <Part Name="MONSTER_PART_WINGS" Group="WING"/>
+      <Part Name="MONSTER_PART_WINGS_ICE" Group="WING"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_ARMS_ICE" Group="ARM"/>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
+      <Part Name="MONSTER_PART_LEGS_ICE" Group="LEG"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_TAIL_ICE" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em125_00" Capture="0" GameID="80"> <!-- Namielle -->
@@ -1153,13 +1218,21 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BACK" Group="BACK" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_WINGS" Group="WING" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="5"/>
+      </Part>
+      <Part Name="MONSTER_PART_BACK" Group="BACK"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
+      <Part Name="MONSTER_PART_WINGS" Group="WING">
+        <Break Threshold="2"/>
+      </Part>
     </Parts>
   </Monster>
   <Monster ID="em126_00" Capture="0" GameID="81"> <!-- Shara Ishvalda -->
@@ -1170,22 +1243,22 @@
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="17">
       <Part Name="MONSTER_PART_REMOVABLE_HEAD" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_LNECK_ROCK" Group="NECK" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RNECK_ROCK" Group="NECK" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_HEAD_ROCK" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL_ROCK" Group="TAIL" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING_ROCK" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING_ROCK" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LARM_ROCK" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RARM_ROCK" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS_ROCK" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_LNECK_ROCK" Group="NECK"/>
+      <Part Name="MONSTER_PART_RNECK_ROCK" Group="NECK"/>
+      <Part Name="MONSTER_PART_HEAD_ROCK" Group="HEAD"/>
+      <Part Name="MONSTER_PART_TAIL_ROCK" Group="TAIL"/>
+      <Part Name="MONSTER_PART_LWING_ROCK" Group="WING"/>
+      <Part Name="MONSTER_PART_RWING_ROCK" Group="WING"/>
+      <Part Name="MONSTER_PART_LARM_ROCK" Group="ARM"/>
+      <Part Name="MONSTER_PART_RARM_ROCK" Group="ARM"/>
+      <Part Name="MONSTER_PART_LEGS_ROCK" Group="LEG"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING"/>
+      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
   <Monster ID="em127_00" Capture="0" GameID="23"> <!-- Leshen -->
@@ -1197,13 +1270,13 @@
     <Parts Max="9">
       <Part Name="MONSTER_PART_REMOVABLE_LANTLER" IsRemovable="True"/>
       <Part Name="MONSTER_PART_REMOVABLE_RANTLER" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_UNKNOWN" Group="MISC" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_UNKNOWN" Group="MISC" IsRemovable="False"/>
-      <Part Name="MONSTER_JAGRAS_SUMMONER" Group="MISC" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_UNKNOWN" Group="MISC"/>
+      <Part Name="MONSTER_PART_UNKNOWN" Group="MISC"/>
+      <Part Name="MONSTER_JAGRAS_SUMMONER" Group="MISC"/>
     </Parts>
   </Monster>
   <Monster ID="em127_01" Capture="0" GameID="51"> <!-- Ancient Leshen -->
@@ -1215,13 +1288,13 @@
     <Parts Max="9">
       <Part Name="MONSTER_PART_REMOVABLE_LANTLER" IsRemovable="True"/>
       <Part Name="MONSTER_PART_REMOVABLE_RANTLER" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_UNKNOWN" Group="MISC" IsRemovable="False"/>
-      <Part Name="MONSTER_PART_UNKNOWN" Group="MISC" IsRemovable="False"/>
-      <Part Name="MONSTER_JAGRAS_SUMMONER" Group="MISC" IsRemovable="False"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_UNKNOWN" Group="MISC"/>
+      <Part Name="MONSTER_PART_UNKNOWN" Group="MISC"/>
+      <Part Name="MONSTER_JAGRAS_SUMMONER" Group="MISC"/>
     </Parts>
   </Monster>
 </Monsters>

--- a/HunterPie/Resources/DefaultTheme.xaml
+++ b/HunterPie/Resources/DefaultTheme.xaml
@@ -110,7 +110,7 @@
         <Setter Property="FontSize" Value="12"/>
     </Style>
 
-    <Style x:Key="OVERLAY_MONSTER_PART_COUNTER_BACKGROUND_STYLE" TargetType="Rectangle">
+    <Style x:Key="OVERLAY_MONSTER_PART_COUNTER_BACKGROUND_STYLE" TargetType="{x:Type Shape}">
         <Setter Property="Fill" Value="#FFB9B9B9"/>
         <Setter Property="Stroke" Value="#CC0E0E0E"/>
         <Setter Property="StrokeThickness" Value="0.5"/>
@@ -127,11 +127,6 @@
         </Setter>
         <Setter Property="FontWeight" Value="SemiBold"/>
         <Setter Property="FontSize" Value="14"/>
-        <Setter Property="Effect">
-            <Setter.Value>
-                <DropShadowEffect BlurRadius="0" ShadowDepth="1" Color="#FF2E2E2E"/>
-            </Setter.Value>
-        </Setter>
     </Style>
 
     <!-- Console -->

--- a/HunterPie/Themes/CutePie.xaml
+++ b/HunterPie/Themes/CutePie.xaml
@@ -73,7 +73,7 @@
         <Setter Property="FontSize" Value="12"/>
     </Style>
 
-    <Style x:Key="OVERLAY_MONSTER_PART_COUNTER_BACKGROUND_STYLE" TargetType="Rectangle">
+    <Style x:Key="OVERLAY_MONSTER_PART_COUNTER_BACKGROUND_STYLE" TargetType="{x:Type Shape}">
         <Setter Property="Fill" Value="#631df1"/>
         <Setter Property="Stroke" Value="#CC0E0E0E"/>
         <Setter Property="StrokeThickness" Value="0"/>

--- a/HunterPie/Themes/PinkyPie.xaml
+++ b/HunterPie/Themes/PinkyPie.xaml
@@ -72,7 +72,7 @@
         <Setter Property="FontSize" Value="12"/>
     </Style>
 
-    <Style x:Key="OVERLAY_MONSTER_PART_COUNTER_BACKGROUND_STYLE" TargetType="Rectangle">
+    <Style x:Key="OVERLAY_MONSTER_PART_COUNTER_BACKGROUND_STYLE" TargetType="{x:Type Shape}">
         <Setter Property="Fill" Value="#FFFF65C0"/>
         <Setter Property="Stroke" Value="#CC0E0E0E"/>
         <Setter Property="StrokeThickness" Value="0"/>

--- a/HunterPie/Themes/RedMonsterBar.xaml
+++ b/HunterPie/Themes/RedMonsterBar.xaml
@@ -61,7 +61,7 @@
         <Setter Property="FontSize" Value="12"/>
     </Style>
 
-    <Style x:Key="OVERLAY_MONSTER_PART_COUNTER_BACKGROUND_STYLE" TargetType="Rectangle">
+    <Style x:Key="OVERLAY_MONSTER_PART_COUNTER_BACKGROUND_STYLE" TargetType="{x:Type Shape}">
         <Setter Property="Fill" Value="#FF9E0900"/>
         <Setter Property="Stroke" Value="#CC0E0E0E"/>
         <Setter Property="StrokeThickness" Value="0"/>


### PR DESCRIPTION
### This adds backend support for part breaks, as per #30, and partial frontend modifications.

The GUI will need more space for extra info unless it's moved to another place.
If you want to temporarily revert the formatting for GUI, take a look at `UpdatePartBrokenCounter`.
The related code was cleaned up a bit to make the necessary extra work easier.

Only a few monsters were edited with data from @nicodiaz55, namely: Gold Rathian, Silver Rathalos, Savage Deviljho, Zinogre, Stygian Zinogre, Safi'jiiva, Kulve Taroth