### PR TITLE
Add the remaining monster part breaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.fake
+.ionide
 .vs
 bin
 obj

--- a/.idea/.idea.HunterPie/.idea/.gitignore
+++ b/.idea/.idea.HunterPie/.idea/.gitignore
@@ -1,0 +1,13 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/modules.xml
+/contentModel.xml
+/.idea.HunterPie.iml
+/projectSettingsUpdater.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/.idea.HunterPie/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/.idea.HunterPie/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+﻿<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/.idea.HunterPie/.idea/encodings.xml
+++ b/.idea/.idea.HunterPie/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/.idea/.idea.HunterPie/.idea/indexLayout.xml
+++ b/.idea/.idea.HunterPie/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ContentModelUserStore">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.HunterPie/.idea/misc.xml
+++ b/.idea/.idea.HunterPie/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="com.jetbrains.rider.android.RiderAndroidMiscFileCreationComponent">
+    <option name="ENSURE_MISC_FILE_EXISTS" value="true" />
+  </component>
+</project>

--- a/.idea/.idea.HunterPie/.idea/vcs.xml
+++ b/.idea/.idea.HunterPie/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.idea/.idea.HunterPie/riderModule.iml
+++ b/.idea/.idea.HunterPie/riderModule.iml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="RIDER_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$/../.." />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/HunterPie/HunterPie.Resources/Data/MonsterData.xml
+++ b/HunterPie/HunterPie.Resources/Data/MonsterData.xml
@@ -34,11 +34,21 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
@@ -51,11 +61,21 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
@@ -95,11 +115,21 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
@@ -112,11 +142,21 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
@@ -156,10 +196,17 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="9">
-      <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
+      <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True">
+        <Break Threshold="1"/>
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LWING" Group="WING"/>
       <Part Name="MONSTER_PART_RWING" Group="WING"/>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
@@ -174,10 +221,17 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="9">
-      <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
+      <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True">
+        <Break Threshold="1"/>
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LWING" Group="WING"/>
       <Part Name="MONSTER_PART_RWING" Group="WING"/>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
@@ -192,7 +246,9 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="3">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="8"/>
+      </Part>
       <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
       <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
     </Parts>
@@ -204,13 +260,24 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+        <Break Threshold="4"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
@@ -221,13 +288,24 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+        <Break Threshold="4"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
@@ -238,16 +316,26 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.11" Gold="1.18"/>
     <Parts Max="11">
-      <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
+      <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RARM" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
-      <Part Name="MONSTER_PART_REMOVABLE_HORNS_2" IsRemovable="True"/>
+      <Part Name="MONSTER_PART_REMOVABLE_HORNS_2" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_UNKNOWN" IsRemovable="True"/>
     </Parts>
   </Monster>
@@ -258,16 +346,24 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.11" Gold="1.18"/>
     <Parts Max="11">
-      <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True"/>
+      <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL" IsRemovable="True"/>
       <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RARM" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
-      <Part Name="MONSTER_PART_REMOVABLE_HORNS_2" IsRemovable="True"/>
+      <Part Name="MONSTER_PART_REMOVABLE_HORNS_2" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_UNKNOWN" IsRemovable="True"/>
     </Parts>
   </Monster>
@@ -278,13 +374,17 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
       <Part Name="MONSTER_PART_LLIMBS" Group="LIMB"/>
       <Part Name="MONSTER_PART_RLIMBS" Group="LIMB"/>
-      <Part Name="MONSTER_PART_WINGS" Group="WING"/>
+      <Part Name="MONSTER_PART_WINGS" Group="WING">
+        <Break Threshold="2"/>
+      </Part>
     </Parts>
   </Monster>
   <Monster ID="em026_00" Capture="0"  GameID="17"> <!-- Lunastra -->
@@ -294,12 +394,18 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
       <Part Name="MONSTER_PART_LIMBS" Group="LIMB"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_RWING" Group="WING">
+        <Break Threshold="2"/>
+      </Part>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
@@ -310,12 +416,16 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
       <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
       <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
-      <Part Name="MONSTER_PART_WINGS" Group="WING"/>
+      <Part Name="MONSTER_PART_WINGS" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
@@ -326,11 +436,19 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_RARM" Group="ARM">
+        <Break Threshold="2"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
@@ -343,11 +461,19 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_RARM" Group="ARM">
+        <Break Threshold="2"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
@@ -360,12 +486,22 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="6">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="6"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="2"/>
+      </Part>
       <Part Name="MONSTER_PART_ABDOMEN" Group="ABDOMEN"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG">
+        <Break Threshold="4"/>
+      </Part>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG">
+        <Break Threshold="4"/>
+      </Part>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL">
+        <Break Threshold="4"/>
+      </Part>
     </Parts>
   </Monster>
   <Monster ID="em037_00" Capture="20"  GameID="62"> <!-- Nargacuga -->
@@ -375,11 +511,19 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="4"/>
+      </Part>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RARM" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
@@ -392,11 +536,19 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="4"/>
+      </Part>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RARM" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
@@ -409,10 +561,16 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.10" Gold="1.20"/>
     <Parts Max="9">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="3"/>
+      </Part>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_CHEST" Group="CHEST"/>
+      <Part Name="MONSTER_PART_CHEST" Group="CHEST">
+        <Break Threshold="5"/>
+      </Part>
       <Part Name="MONSTER_PART_REAR" Group="REAR"/>
       <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
@@ -451,20 +609,42 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="14">
-      <Part Name="MONSTER_PART_REMOVABLE_HEAD" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
+      <Part Name="MONSTER_PART_REMOVABLE_HEAD" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_HEAD_MUD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_HEAD_MUD" Group="HEAD">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_BODY_MUD" Group="BODY"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
-      <Part Name="MONSTER_PART_ARMS_MUD" Group="ARM"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
-      <Part Name="MONSTER_PART_LLEG_MUD" Group="LEG"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
-      <Part Name="MONSTER_PART_RLEG_MUD" Group="LEG"/>
+      <Part Name="MONSTER_PART_BODY_MUD" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_ARMS_MUD" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LLEG_MUD" Group="LEG">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RLEG_MUD" Group="LEG">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
-      <Part Name="MONSTER_PART_TAIL_MUD" Group="TAIL"/>
+      <Part Name="MONSTER_PART_TAIL_MUD" Group="TAIL">
+        <Break Threshold="1"/>
+      </Part>
     </Parts>
   </Monster>
   <Monster ID="em045_00" Capture="20"  GameID="22"> <!-- Uragaan -->
@@ -474,14 +654,22 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.10" Gold="1.20"/>
     <Parts Max="8">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_JAW" Group="JAW"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_JAW" Group="JAW">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL">
+        <Break Threshold="1"/>
+      </Part>
     </Parts>
   </Monster>
   <Monster ID="em057_00" Capture="20"  GameID="94"> <!-- Zinogre -->
@@ -541,11 +729,19 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="8">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="4"/>
+      </Part>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_RARM" Group="ARM">
+        <Break Threshold="2"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
@@ -558,12 +754,20 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="10">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
       <Part Name="MONSTER_PART_BACK" Group="BACK"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_RARM" Group="ARM">
+        <Break Threshold="2"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
@@ -577,14 +781,25 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.10" Gold="1.20"/>
     <Parts Max="8">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_FIN" Group="FIN"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="1"/>
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_FIN" Group="FIN">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL">
+        <Break Threshold="1"/>
+      </Part>
     </Parts>
   </Monster>
   <Monster ID="em080_01" Capture="20"  GameID="67"> <!-- Acidic Glavenus -->
@@ -594,14 +809,23 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.10" Gold="1.20"/>
     <Parts Max="8">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="1"/>
+        <Break Threshold="2"/>
+      </Part>
       <Part Name="MONSTER_PART_FIN" Group="FIN"/>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL">
+        <Break Threshold="1"/>
+      </Part>
     </Parts>
   </Monster>
   <Monster ID="em100_00" Capture="25"  GameID="0"> <!-- Anjanath -->
@@ -611,11 +835,19 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.10" Gold="1.20"/>
     <Parts Max="6">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="5"/>
+      </Part>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG">
+        <Break Threshold="3"/>
+      </Part>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG">
+        <Break Threshold="3"/>
+      </Part>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
@@ -626,11 +858,19 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.10" Gold="1.20"/>
     <Parts Max="6">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="5"/>
+      </Part>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG">
+        <Break Threshold="3"/>
+      </Part>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG">
+        <Break Threshold="3"/>
+      </Part>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
@@ -641,12 +881,18 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="6">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
-      <Part Name="MONSTER_PART_ABDOMEN" Group="ABDOMEN"/>
+      <Part Name="MONSTER_PART_ABDOMEN" Group="ABDOMEN">
+        <Break Threshold="3"/>
+      </Part>
     </Parts>
   </Monster>
   <Monster ID="em102_00" Capture="25"  GameID="24"> <!-- Pukei-Pukei -->
@@ -657,11 +903,21 @@
     <Crown Mini="0.9" Silver="1.10" Gold="1.20"/>
     <Parts Max="9">
       <Part Name="MONSTER_PART_REMOVABLE_HEAD" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LWING" Group="WING">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_RWING" Group="WING">
+        <Break Threshold="2"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
@@ -674,11 +930,21 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.10" Gold="1.20"/>
     <Parts Max="8">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
@@ -691,8 +957,13 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="12">
-      <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
+      <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True">
+        <Break Threshold="2"/>
+        <Break Threshold="3"/>
+      </Part>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_HORNS" Group="HORN"/>
       <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
@@ -711,9 +982,7 @@
       <Weakness ID="ELEMENT_THUNDER" Stars="2"/>
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
-    <Parts Max="12">
-      <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
+    <Parts Max="23">
       <Part Name="MONSTER_PART_HORNS" Group="HORN"/>
       <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
@@ -724,6 +993,34 @@
       <Part Name="MONSTER_PART_LWING" Group="WING"/>
       <Part Name="MONSTER_PART_RWING" Group="WING"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_HEAD" IsRemovable="True"/> <!-- bw spikes -->
+      <Part Name="MONSTER_PART_LARM" IsRemovable="True"/> <!-- bw spikes -->
+      <Part Name="MONSTER_PART_LWING" IsRemovable="True"/> <!-- bw spikes -->
+      <Part Name="MONSTER_PART_RWING" IsRemovable="True"/> <!-- bw spikes -->
+      <Part Name="MONSTER_PART_RARM" IsRemovable="True"/> <!-- bw spikes -->
+      <Part Name="MONSTER_PART_TAIL" IsRemovable="True"/> <!-- bw spikes -->
+      <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True"> <!-- two horns  -->
+        <Break Threshold="2"/>
+        <Break Threshold="4"/>
+      </Part>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"> <!-- removable tail -->
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" IsRemovable="True"> <!-- silver spikes -->
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LARM" IsRemovable="True"> <!-- silver spikes -->
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RARM" IsRemovable="True"> <!-- silver spikes -->
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LWING" IsRemovable="True"> <!-- silver spikes -->
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RWING" IsRemovable="True"> <!-- silver spikes -->
+        <Break Threshold="1"/>
+      </Part>
     </Parts>
   </Monster>
   <Monster ID="em104_00" Capture="0"  GameID="97"> <!-- Safi'jiiva -->
@@ -776,16 +1073,26 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="11">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
       <Part Name="MONSTER_PART_NECK" Group="NECK" />
       <Part Name="MONSTER_PART_BACK" Group="BACK"/>
       <Part Name="MONSTER_PART_CHEST" Group="CHEST"/>
-      <Part Name="MONSTER_PART_LHAND" Group="ARM"/>
-      <Part Name="MONSTER_PART_RHAND" Group="ARM"/>
+      <Part Name="MONSTER_PART_LHAND" Group="ARM">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_RHAND" Group="ARM">
+        <Break Threshold="2"/>
+      </Part>
       <Part Name="MONSTER_PART_LFOOT" Group="LEG"/>
       <Part Name="MONSTER_PART_RFOOT" Group="LEG"/>
-      <Part Name="MONSTER_PART_WINGS" Group="WING"/>
+      <Part Name="MONSTER_PART_WINGS" Group="WING">
+        <Break Threshold="2"/>
+      </Part>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
@@ -820,8 +1127,12 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="5">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
       <Part Name="MONSTER_PART_ROCK" Group="MISC"/>
@@ -834,16 +1145,36 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="10">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
-      <Part Name="MONSTER_PART_HEAD_MUD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_BODY_MUD" Group="BODY"/>
-      <Part Name="MONSTER_PART_LLEG_MUD" Group="LEG"/>
-      <Part Name="MONSTER_PART_RLEG_MUD" Group="LEG"/>
-      <Part Name="MONSTER_PART_TAIL_MUD" Group="TAIL"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="4"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL">
+        <Break Threshold="3"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD_MUD" Group="HEAD">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY_MUD" Group="BODY">
+        <Break Threshold="3"/>
+      </Part>
+      <Part Name="MONSTER_PART_LLEG_MUD" Group="LEG">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_RLEG_MUD" Group="LEG">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_TAIL_MUD" Group="TAIL">
+        <Break Threshold="1"/>
+      </Part>
     </Parts>
   </Monster>
   <Monster ID="em109_00" Capture="25"  GameID="30"> <!-- Tobi-Kadachi -->
@@ -853,12 +1184,20 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.10" Gold="1.20"/>
     <Parts Max="6">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_MANE" Group="MANE"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_MANE" Group="MANE">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL">
+        <Break Threshold="4"/>
+      </Part>
     </Parts>
   </Monster>
   <Monster ID="em109_01" Capture="25" GameID="71"> <!-- Viper Tobi-Kadachi -->
@@ -868,11 +1207,19 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.10" Gold="1.20"/>
     <Parts Max="6">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_MANE" Group="MANE"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
+      <Part Name="MONSTER_PART_MANE" Group="MANE">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
@@ -883,15 +1230,25 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="9">
-      <Part Name="MONSTER_PART_REMOVABLE_BALLOON" IsRemovable="True"/>
+      <Part Name="MONSTER_PART_REMOVABLE_BALLOON" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
       <Part Name="MONSTER_PART_BALLOON" Group="HEAD"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL">
+        <Break Threshold="1"/>
+      </Part>
     </Parts>
   </Monster>
   <Monster ID="em110_01" Capture="25" GameID="72"> <!-- Nightshade Paolumu -->
@@ -901,15 +1258,25 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="9">
-      <Part Name="MONSTER_PART_REMOVABLE_BALLOON" IsRemovable="True"/>
+      <Part Name="MONSTER_PART_REMOVABLE_BALLOON" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
       <Part Name="MONSTER_PART_BALLOON" Group="HEAD"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL">
+        <Break Threshold="1"/>
+      </Part>
     </Parts>
   </Monster>
   <Monster ID="em111_00" Capture="20" GameID="32"> <!-- Legiana -->
@@ -919,13 +1286,23 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL">
+        <Break Threshold="1"/>
+      </Part>
     </Parts>
   </Monster>
   <Monster ID="em111_05" Capture="15" GameID="73"> <!-- Shrieking Legiana -->
@@ -935,13 +1312,23 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
-	  <Part Name="MONSTER_PART_UNKNOWN" Group="HEAD" IsRemovable="True"/>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL">
+        <Break Threshold="1"/>
+      </Part>
+	    <Part Name="MONSTER_PART_UNKNOWN" Group="HEAD" IsRemovable="True"/>
     </Parts>
   </Monster>
   <Monster ID="em112_00" Capture="30" GameID="33"> <!-- Great Girros -->
@@ -951,10 +1338,16 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="6">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
@@ -966,13 +1359,24 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="1"/>
+        <Break Threshold="2"/>
+      </Part>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
-	  <Part Name="MONSTER_PART_UNKNOWN" IsRemovable="True"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL">
+        <Break Threshold="1"/>
+      </Part>
+	    <Part Name="MONSTER_PART_UNKNOWN" IsRemovable="True"/>
     </Parts>
   </Monster>
   <Monster ID="em113_01" Capture="15"  GameID="74"> <!-- Ebony Odogaron -->
@@ -984,12 +1388,22 @@
     <Parts Max="8">
       <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
-	  <Part Name="MONSTER_PART_UNKNOWN" IsRemovable="True"/>
-	  <Part Name="MONSTER_PART_REMOVABLE_HEAD" IsRemovable="True"/>
-	  <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_UNKNOWN" IsRemovable="True"/>
+      <Part Name="MONSTER_PART_REMOVABLE_HEAD" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
     </Parts>
   </Monster>
   <Monster ID="em114_00" Capture="25"  GameID="35"> <!-- Radobaan -->
@@ -999,16 +1413,30 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.10" Gold="1.20"/>
     <Parts Max="10">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
-      <Part Name="MONSTER_PART_JAW" Group="JAW"/>
-      <Part Name="MONSTER_PART_BACK" Group="BACK"/>
-      <Part Name="MONSTER_PART_LBONE" Group="BONE"/>
-      <Part Name="MONSTER_PART_RBONE" Group="BONE"/>
+      <Part Name="MONSTER_PART_JAW" Group="JAW">
+        <Break Threshold="1"/>
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_BACK" Group="BACK">
+        <Break Threshold="1"/>
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_LBONE" Group="BONE">
+        <Break Threshold="1"/>
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_RBONE" Group="BONE">
+        <Break Threshold="1"/>
+        <Break Threshold="2"/>
+      </Part>
     </Parts>
   </Monster>
   <Monster ID="em115_00" Capture="0"  GameID="36"> <!-- Vaal Hazak -->
@@ -1018,17 +1446,27 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="11">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
       <Part Name="MONSTER_PART_BACK" Group="BACK"/>
-      <Part Name="MONSTER_PART_CHEST" Group="CHEST"/>
+      <Part Name="MONSTER_PART_CHEST" Group="CHEST">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RARM" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_WINGS" Group="WING"/>
       <Part Name="MONSTER_PART_UNKNOWN" Group="MISC" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
     </Parts>
   </Monster>
   <Monster ID="em115_05" Capture="0"  GameID="75"> <!-- Blackveil Vaal Hazak -->
@@ -1038,17 +1476,27 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="11">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="3"/>
+      </Part>
       <Part Name="MONSTER_PART_BACK" Group="BACK"/>
-      <Part Name="MONSTER_PART_CHEST" Group="CHEST"/>
+      <Part Name="MONSTER_PART_CHEST" Group="CHEST">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RARM" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_WINGS" Group="WING"/>
-	  <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-	  <Part Name="MONSTER_PART_UNKNOWN" Group="MISC" IsRemovable="True"/>
+	    <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+	    <Part Name="MONSTER_PART_UNKNOWN" Group="MISC" IsRemovable="True"/>
     </Parts>
   </Monster>
   <Monster ID="em116_00" Capture="30" GameID="37"> <!-- Dodogama -->
@@ -1058,10 +1506,16 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="6">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="5"/>
+      </Part>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
+      <Part Name="MONSTER_PART_ARMS" Group="ARM">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
@@ -1126,12 +1580,22 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
@@ -1142,12 +1606,22 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
-      <Part Name="MONSTER_PART_LWING" Group="WING"/>
-      <Part Name="MONSTER_PART_RWING" Group="WING"/>
+      <Part Name="MONSTER_PART_LWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RWING" Group="WING">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
@@ -1158,7 +1632,9 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="5">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
       <Part Name="MONSTER_PART_UNKNOWN" Group="MISC"/>
       <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
       <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
@@ -1172,12 +1648,21 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="9">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HORNS" Group="HORN"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HORNS" Group="HORN">
+        <Break Threshold="2"/>
+        <Break Threshold="3"/>
+      </Part>
       <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_LARM" Group="ARM"/>
-      <Part Name="MONSTER_PART_RARM" Group="ARM"/>
+      <Part Name="MONSTER_PART_LARM" Group="ARM">
+        <Break Threshold="3"/>
+      </Part>
+      <Part Name="MONSTER_PART_RARM" Group="ARM">
+        <Break Threshold="3"/>
+      </Part>
       <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
@@ -1190,13 +1675,27 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
-      <Part Name="MONSTER_PART_HEAD_SNOW" Group="HEAD"/>
-      <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_BODY_SNOW" Group="BODY"/>
-      <Part Name="MONSTER_PART_LEGS" Group="LEG"/>
-      <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
-      <Part Name="MONSTER_PART_TAIL_SNOW" Group="TAIL"/>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD_SNOW" Group="HEAD">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_BODY_SNOW" Group="BODY">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_LEGS" Group="LEG">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_TAIL" Group="TAIL">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_TAIL_SNOW" Group="TAIL">
+        <Break Threshold="1"/>
+      </Part>
     </Parts>
   </Monster>
   <Monster ID="em123_00" Capture="25" GameID="78"> <!-- Banbaro -->
@@ -1206,12 +1705,21 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="7">
-      <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
+      <Part Name="MONSTER_PART_REMOVABLE_HORNS" IsRemovable="True">
+        <Break Threshold="1"/>
+        <Break Threshold="2"/>
+      </Part>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_HORNS" Group="HORN"/>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
-      <Part Name="MONSTER_PART_LLEG" Group="LEG"/>
-      <Part Name="MONSTER_PART_RLEG" Group="LEG"/>
+      <Part Name="MONSTER_PART_LLEG" Group="LEG">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_RLEG" Group="LEG">
+        <Break Threshold="1"/>
+      </Part>
       <Part Name="MONSTER_PART_TAIL" Group="TAIL"/>
     </Parts>
   </Monster>
@@ -1222,12 +1730,18 @@
     </Weaknesses>
     <Crown Mini="0.9" Silver="1.15" Gold="1.23"/>
     <Parts Max="13">
-      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True"/>
-      <Part Name="MONSTER_PART_HEAD" Group="HEAD"/>
+      <Part Name="MONSTER_PART_REMOVABLE_TAIL" IsRemovable="True">
+        <Break Threshold="1"/>
+      </Part>
+      <Part Name="MONSTER_PART_HEAD" Group="HEAD">
+        <Break Threshold="2"/>
+      </Part>
       <Part Name="MONSTER_PART_HEAD_ICE" Group="HEAD"/>
       <Part Name="MONSTER_PART_BODY" Group="BODY"/>
       <Part Name="MONSTER_PART_BODY_ICE" Group="BODY"/>
-      <Part Name="MONSTER_PART_WINGS" Group="WING"/>
+      <Part Name="MONSTER_PART_WINGS" Group="WING">
+        <Break Threshold="2"/>
+      </Part>
       <Part Name="MONSTER_PART_WINGS_ICE" Group="WING"/>
       <Part Name="MONSTER_PART_ARMS" Group="ARM"/>
       <Part Name="MONSTER_PART_ARMS_ICE" Group="ARM"/>

--- a/HunterPie/Resources/ConsoleResources.xaml
+++ b/HunterPie/Resources/ConsoleResources.xaml
@@ -1,6 +1,5 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:local="clr-namespace:HunterPie.Resources">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <DrawingImage x:Key="ICON_LINK">
         <DrawingImage.Drawing>
             <DrawingGroup ClipGeometry="M0,0 V1000 H1000 V0 H0 Z">

--- a/HunterPie/Resources/ScrollbarStyle.xaml
+++ b/HunterPie/Resources/ScrollbarStyle.xaml
@@ -1,6 +1,5 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:local="clr-namespace:HunterPie.Resources">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <SolidColorBrush x:Key="StandardBorderBrush" Color="#888" />
     <SolidColorBrush x:Key="StandardBackgroundBrush" Color="Black" />
     <SolidColorBrush x:Key="HoverBorderBrush" Color="#DDD" />
@@ -153,7 +152,7 @@
                 <Setter Property="Height" Value="Auto" />
                 <Setter Property="Template" Value="{StaticResource VerticalScrollBar}" />
             </Trigger>
-            
+
         </Style.Triggers>
     </Style>
 


### PR DESCRIPTION
This should add the rest of the part break thresholds for #30 with a few exceptions:

Not added monsters:
- Zorah Magdaros
- Shara Ishvalda
- Leshen
- Ancient Leshen

Parts:
Elder dragon head break is missing. It can occur only on the first flinch after general monster health threshold is passed.
This functionality is not implemented yet