### PR TITLE
Add Capacity for Themes to customize Monster Container

### DIFF
--- a/HunterPie/GUI/Widgets/Monster Widget/MonsterContainer.xaml
+++ b/HunterPie/GUI/Widgets/Monster Widget/MonsterContainer.xaml
@@ -7,5 +7,5 @@
              xmlns:local="clr-namespace:HunterPie.GUI.Widgets"
              mc:Ignorable="d" 
              MinWidth="895" MinHeight="80" ResizeMode="NoResize" SizeToContent="WidthAndHeight" WindowStyle="None" AllowsTransparency="True" ShowInTaskbar="False" Topmost="True" Closing="OnClosing" Background="{x:Null}" MouseDown="OnMouseDown" MouseWheel="OnMouseWheel" SnapsToDevicePixels="True">
-    <StackPanel x:Name="Container" Orientation="Horizontal" SnapsToDevicePixels="True" RenderTransformOrigin="0.5,0.5" Margin="0" VerticalAlignment="Top" HorizontalAlignment="Center"/>
+    <StackPanel x:Name="Container" Orientation="Horizontal" SnapsToDevicePixels="True" RenderTransformOrigin="0.5,0.5" Margin="0" VerticalAlignment="Top" HorizontalAlignment="Center" Style="{DynamicResource OVERLAY_MONSTER_BACKGROUND}"/>
 </src:Widget>

--- a/HunterPie/Resources/DefaultTheme.xaml
+++ b/HunterPie/Resources/DefaultTheme.xaml
@@ -39,7 +39,15 @@
     </Style>
     
     <SolidColorBrush x:Key="OVERLAY_BARS_BACKGROUND">#7F131313</SolidColorBrush>
-    
+
+    <Style x:Key="OVERLAY_MONSTER_BACKGROUND" TargetType="StackPanel">
+        <Setter Property="Background">
+            <Setter.Value>
+                <SolidColorBrush Color="#FF111111" Opacity="0" />
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <LinearGradientBrush x:Key="OVERLAY_MONSTER_STAMINA_BAR_COLOR" EndPoint="1,0" StartPoint="0,0">
         <GradientStop Color="#E5ECAF2F" Offset="1"/>
         <GradientStop Color="#E5DE9F15"/>

--- a/HunterPie/Resources/DefaultTheme.xaml
+++ b/HunterPie/Resources/DefaultTheme.xaml
@@ -40,13 +40,7 @@
     
     <SolidColorBrush x:Key="OVERLAY_BARS_BACKGROUND">#7F131313</SolidColorBrush>
 
-    <Style x:Key="OVERLAY_MONSTER_BACKGROUND" TargetType="StackPanel">
-        <Setter Property="Background">
-            <Setter.Value>
-                <SolidColorBrush Color="#FF111111" Opacity="0" />
-            </Setter.Value>
-        </Setter>
-    </Style>
+    <Style x:Key="OVERLAY_MONSTER_BACKGROUND" TargetType="StackPanel" />
 
     <LinearGradientBrush x:Key="OVERLAY_MONSTER_STAMINA_BAR_COLOR" EndPoint="1,0" StartPoint="0,0">
         <GradientStop Color="#E5ECAF2F" Offset="1"/>

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -26,6 +26,7 @@ If you look at the file content, you'll see that all styles have a Key, that's t
 | OVERLAY_MONSTER_PART_NAME_TEXT_STYLE          | Style | Changes the monster part name text.                                                    |
 | OVERLAY_MONSTER_PART_COUNTER_BACKGROUND_STYLE | Style | Changes the prism color that is on the left side of the part bar.                      |
 | OVERLAY_MONSTER_PART_COUNTER_TEXT_STYLE       | Style | Changes the text style of the prism that is on the left side of the part/ailments bar. |
+| OVERLAY_MONSTER_BACKGROUND                    | Style | Changes the monster container style.                                                   |
 
 ## Colors, Gradients, etc...
 


### PR DESCRIPTION
I wanted to be able to add a semi-transparent background so I could see what was written as I put the monster container on a 2nd screen w/ ever changing backgrounds making any color impossible to really read.

With this I can we can do pretty much anything, but I've got my background so there's that :)