### PR TITLE
Add monster health info hiding setting

### DIFF
--- a/HunterPie/Core/Client/UserSettings.cs
+++ b/HunterPie/Core/Client/UserSettings.cs
@@ -68,6 +68,7 @@ namespace HunterPie.Core
                 public bool Enabled { get; set; } = true;
                 public double Scale { get; set; } = 1;
                 public string HealthTextFormat { get; set; } = "{Health:0}/{TotalHealth:0} ({Percentage:0}%)";
+                public bool HideHealthInformation { get; set; }
                 public byte ShowMonsterBarMode { get; set; } = 0;
                 public string SwitchMonsterBarModeHotkey = "Alt+Up";
                 public int[] Position { get; set; } = new int[] { 335, 10 };
@@ -161,7 +162,7 @@ namespace HunterPie.Core
 
             public class Update
             {
-                public bool Enabled { get; set; } = true;
+                public bool Enabled { get; set; } = false;
                 public string Branch { get; set; } = "master";
             }
 

--- a/HunterPie/Core/Client/UserSettings.cs
+++ b/HunterPie/Core/Client/UserSettings.cs
@@ -162,7 +162,7 @@ namespace HunterPie.Core
 
             public class Update
             {
-                public bool Enabled { get; set; } = false;
+                public bool Enabled { get; set; } = true;
                 public string Branch { get; set; } = "master";
             }
 

--- a/HunterPie/GUI/Widgets/Monster Widget/MonsterHealth.xaml.cs
+++ b/HunterPie/GUI/Widgets/Monster Widget/MonsterHealth.xaml.cs
@@ -110,9 +110,9 @@ namespace HunterPie.GUI.Widgets
             MonsterStaminaBar.MaxSize = Width - 72;
 
             // Update monster health and stamina
-            MonsterHealthBar.UpdateBar(Monster.Health, Monster.MaxHealth);
+            UpdateHealthBar(MonsterHealthBar, Monster.Health, Monster.MaxHealth);
+            UpdateHealthBar(MonsterStaminaBar, Monster.Stamina, Monster.MaxStamina);
             SetMonsterHealthBarText(Monster.Health, Monster.MaxHealth);
-            MonsterStaminaBar.UpdateBar(Monster.Stamina, Monster.MaxStamina);
             SetMonsterStaminaText(Monster.Stamina, Monster.MaxStamina);
             DisplayCapturableIcon(Monster.Health, Monster.MaxHealth, Monster.CaptureThreshold);
 
@@ -217,7 +217,7 @@ namespace HunterPie.GUI.Widgets
 
         private void OnStaminaUpdate(object source, MonsterUpdateEventArgs args) => Dispatch(() =>
         {
-            MonsterStaminaBar.UpdateBar(args.Stamina, args.MaxStamina);
+            UpdateHealthBar(MonsterStaminaBar, args.Stamina, args.MaxStamina);
             SetMonsterStaminaText(args.Stamina, args.MaxStamina);
         });
 
@@ -251,8 +251,7 @@ namespace HunterPie.GUI.Widgets
 
         private void OnMonsterUpdate(object source, MonsterUpdateEventArgs args) => Dispatch(() =>
         {
-            MonsterHealthBar.MaxValue = args.MaxHealth;
-            MonsterHealthBar.Value = args.Health;
+            UpdateHealthBar(MonsterHealthBar, args.Health, args.MaxHealth);
             SetMonsterHealthBarText(args.Health, args.MaxHealth);
             DisplayCapturableIcon(args.Health, args.MaxHealth, Context.CaptureThreshold);
             if (UserSettings.PlayerConfig.Overlay.MonstersComponent.ShowMonsterBarMode == 3)
@@ -484,8 +483,8 @@ namespace HunterPie.GUI.Widgets
             UpdateContainerBarsSizeDynamically();
             MonsterHealthBar.MaxSize = NewSize - 69;
             MonsterStaminaBar.MaxSize = NewSize - 72;
-            MonsterHealthBar.UpdateBar(Context.Health, Context.MaxHealth);
-            MonsterStaminaBar.UpdateBar(Context.Stamina, Context.MaxStamina);
+            UpdateHealthBar(MonsterHealthBar, Context.Health, Context.MaxHealth);
+            UpdateHealthBar(MonsterStaminaBar, Context.Stamina, Context.MaxStamina);
         }
 
         private void UpdateContainerBarsSizeDynamically()
@@ -579,6 +578,14 @@ namespace HunterPie.GUI.Widgets
                 CapturableIcon.Visibility = Visibility.Hidden;
             }
 
+        }
+
+        private void UpdateHealthBar(MinimalHealthBar healthBar, float newValue, float maxValue)
+        {
+            float updateValue = UserSettings.PlayerConfig.Overlay.MonstersComponent.HideHealthInformation
+                ? maxValue
+                : newValue;
+            healthBar.UpdateBar(updateValue, maxValue);
         }
         #endregion
 

--- a/HunterPie/GUI/Widgets/Monster Widget/MonsterHealth.xaml.cs
+++ b/HunterPie/GUI/Widgets/Monster Widget/MonsterHealth.xaml.cs
@@ -152,7 +152,7 @@ namespace HunterPie.GUI.Widgets
             }
 
             // Enrage
-            if (Monster.IsEnraged)
+            if (Monster.IsEnraged && !UserSettings.PlayerConfig.Overlay.MonstersComponent.HideHealthInformation)
             {
                 ANIM_ENRAGEDICON.Begin(MonsterHealthBar, true);
                 ANIM_ENRAGEDICON.Begin(HealthBossIcon, true);
@@ -198,13 +198,14 @@ namespace HunterPie.GUI.Widgets
 
         private void OnEnrage(object source, MonsterUpdateEventArgs args) => Dispatch(() =>
         {
+            if (UserSettings.PlayerConfig.Overlay.MonstersComponent.HideHealthInformation) return;
             ANIM_ENRAGEDICON.Begin(MonsterHealthBar, true);
             ANIM_ENRAGEDICON.Begin(HealthBossIcon, true);
         });
 
         private void OnEnrageTimerUpdate(object source, MonsterUpdateEventArgs args)
         {
-            if (Context == null) return;
+            if (Context == null || UserSettings.PlayerConfig.Overlay.MonstersComponent.HideHealthInformation) return;
             int EnrageTimer = (int)Context.EnrageTimerStatic - (int)Context.EnrageTimer;
             Dispatch(() =>
             {

--- a/HunterPie/GUI/Widgets/Monster Widget/MonsterHealth.xaml.cs
+++ b/HunterPie/GUI/Widgets/Monster Widget/MonsterHealth.xaml.cs
@@ -106,17 +106,15 @@ namespace HunterPie.GUI.Widgets
         {
             Visibility = Visibility.Visible;
             MonsterName.Text = Monster.Name;
-            // Update monster health
             MonsterHealthBar.MaxSize = Width * 0.7833333333333333;
+            MonsterStaminaBar.MaxSize = Width - 72;
+
+            // Update monster health and stamina
             MonsterHealthBar.UpdateBar(Monster.Health, Monster.MaxHealth);
             SetMonsterHealthBarText(Monster.Health, Monster.MaxHealth);
-
-            if ((Monster.Health / Monster.MaxHealth * 100) < Monster.CaptureThreshold) CapturableIcon.Visibility = Visibility.Visible;
-
-            // Monster stamina
-            MonsterStaminaBar.MaxSize = Width - 72;
             MonsterStaminaBar.UpdateBar(Monster.Stamina, Monster.MaxStamina);
             SetMonsterStaminaText(Monster.Stamina, Monster.MaxStamina);
+            DisplayCapturableIcon(Monster.Health, Monster.MaxHealth, Monster.CaptureThreshold);
 
             // Gets monster icon
             MonsterIcon.Source = GetMonsterIcon(Monster.Id);
@@ -255,8 +253,7 @@ namespace HunterPie.GUI.Widgets
             MonsterHealthBar.MaxValue = args.MaxHealth;
             MonsterHealthBar.Value = args.Health;
             SetMonsterHealthBarText(args.Health, args.MaxHealth);
-            if ((args.Health / args.MaxHealth * 100) < Context.CaptureThreshold) CapturableIcon.Visibility = Visibility.Visible;
-            else { CapturableIcon.Visibility = Visibility.Collapsed; }
+            DisplayCapturableIcon(args.Health, args.MaxHealth, Context.CaptureThreshold);
             if (UserSettings.PlayerConfig.Overlay.MonstersComponent.ShowMonsterBarMode == 3)
             {
                 Visibility = Visibility.Visible;
@@ -399,7 +396,8 @@ namespace HunterPie.GUI.Widgets
         }
 
 
-        // Show all monsters but hide unactive
+        // Show all monsters but hide inactive
+        // FIXME: typo
         private void ShowAllMonsterAndHideUnactive()
         {
             if (Context == null || !Context.IsAlive) { Visibility = Visibility.Collapsed; return; }
@@ -483,7 +481,6 @@ namespace HunterPie.GUI.Widgets
             MonsterPartsContainer.MaxWidth = config.EnableMonsterAilments ? (NewSize - 2) / 2 : (NewSize - 1);
             MonsterAilmentsContainer.MaxWidth = config.EnableMonsterParts || config.EnableRemovableParts ? (NewSize - 2) / 2 : (NewSize - 1);
             UpdateContainerBarsSizeDynamically();
-            // Monster Bar
             MonsterHealthBar.MaxSize = NewSize - 69;
             MonsterStaminaBar.MaxSize = NewSize - 72;
             MonsterHealthBar.UpdateBar(Context.Health, Context.MaxHealth);
@@ -492,7 +489,6 @@ namespace HunterPie.GUI.Widgets
 
         private void UpdateContainerBarsSizeDynamically()
         {
-
             UserSettings.Config.Monsterscomponent config = UserSettings.PlayerConfig.Overlay.MonstersComponent;
             NumberOfPartsDisplayed = MonsterPartsContainer.Children.Cast<Monster_Widget.Parts.MonsterPart>()
                 .Where(p => p.IsVisible)
@@ -538,17 +534,28 @@ namespace HunterPie.GUI.Widgets
 
         private void SetMonsterHealthBarText(float Health, float TotalHealth)
         {
-            string HealthStringFormat = UserSettings.PlayerConfig.Overlay.MonstersComponent.HealthTextFormat;
-            HealthStringFormat = HealthStringFormat.Replace("{Health:0}", Health.ToString("0"))
-                .Replace("{Health:0.0}", Health.ToString("0.0"))
-                .Replace("{TotalHealth:0}", TotalHealth.ToString("0"))
-                .Replace("{TotalHealth:0.0}", TotalHealth.ToString("0.0"))
-                .Replace("{Percentage:0}", (Health / TotalHealth * 100).ToString("0"))
-                .Replace("{Percentage:0.0}", (Health / TotalHealth * 100).ToString("0.0"));
-            HealthText.Text = HealthStringFormat;
+            if (UserSettings.PlayerConfig.Overlay.MonstersComponent.HideHealthInformation)
+            {
+                HealthText.Text = string.Empty;
+            }
+            else
+            {
+                string HealthStringFormat = UserSettings.PlayerConfig.Overlay.MonstersComponent.HealthTextFormat;
+                HealthStringFormat = HealthStringFormat.Replace("{Health:0}", Health.ToString("0"))
+                    .Replace("{Health:0.0}", Health.ToString("0.0"))
+                    .Replace("{TotalHealth:0}", TotalHealth.ToString("0"))
+                    .Replace("{TotalHealth:0.0}", TotalHealth.ToString("0.0"))
+                    .Replace("{Percentage:0}", (Health / TotalHealth * 100).ToString("0"))
+                    .Replace("{Percentage:0.0}", (Health / TotalHealth * 100).ToString("0.0"));
+                HealthText.Text = HealthStringFormat;
+            }
+
         }
 
-        private void SetMonsterStaminaText(float stam, float max_stam) => StaminaText.Text = $"{stam:0}/{max_stam:0}";
+        private void SetMonsterStaminaText(float stam, float maxStam)
+        {
+            StaminaText.Text = UserSettings.PlayerConfig.Overlay.MonstersComponent.HideHealthInformation ? string.Empty : $"{stam:0}/{maxStam:0}";
+        }
 
         private BitmapImage GetMonsterIcon(string MonsterEm)
         {
@@ -557,6 +564,20 @@ namespace HunterPie.GUI.Widgets
             BitmapImage mIcon = new BitmapImage(ImageURI);
             mIcon.Freeze();
             return mIcon;
+        }
+
+        private void DisplayCapturableIcon(float monsterHealth, float monsterMaxHealth, float monsterCaptureThreshold)
+        {
+            bool captureable = (monsterHealth / monsterMaxHealth * 100) < monsterCaptureThreshold;
+            if (!UserSettings.PlayerConfig.Overlay.MonstersComponent.HideHealthInformation && captureable)
+            {
+                CapturableIcon.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                CapturableIcon.Visibility = Visibility.Hidden;
+            }
+
         }
         #endregion
 

--- a/HunterPie/GUIControls/Custom Controls/MinimalHealthBar.xaml.cs
+++ b/HunterPie/GUIControls/Custom Controls/MinimalHealthBar.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using HunterPie.Core;
 
 namespace HunterPie.GUIControls.Custom_Controls
 {
@@ -20,8 +21,9 @@ namespace HunterPie.GUIControls.Custom_Controls
             set
             {
                 valueProperty = value;
-                double v = Math.Max(MaxSize * (value / Math.Max(MaxValue, 1)), 0);
-                HealthBar.Width = v;
+                HealthBar.Width = UserSettings.PlayerConfig.Overlay.MonstersComponent.HideHealthInformation
+                    ? MaxSize
+                    : Math.Max(MaxSize * (value / Math.Max(MaxValue, 1)), 0);
             }
         }
 

--- a/HunterPie/GUIControls/Custom Controls/MinimalHealthBar.xaml.cs
+++ b/HunterPie/GUIControls/Custom Controls/MinimalHealthBar.xaml.cs
@@ -2,7 +2,6 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
-using HunterPie.Core;
 
 namespace HunterPie.GUIControls.Custom_Controls
 {
@@ -21,9 +20,8 @@ namespace HunterPie.GUIControls.Custom_Controls
             set
             {
                 valueProperty = value;
-                HealthBar.Width = UserSettings.PlayerConfig.Overlay.MonstersComponent.HideHealthInformation
-                    ? MaxSize
-                    : Math.Max(MaxSize * (value / Math.Max(MaxValue, 1)), 0);
+                double v = Math.Max(MaxSize * (value / Math.Max(MaxValue, 1)), 0);
+                HealthBar.Width = v;
             }
         }
 

--- a/HunterPie/GUIControls/NewSettingsWindow.xaml
+++ b/HunterPie/GUIControls/NewSettingsWindow.xaml
@@ -1,9 +1,9 @@
 ﻿<UserControl x:Class="HunterPie.GUIControls.NewSettingsWindow"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:helper="clr-namespace:HunterPie.GUI.Helpers"
              xmlns:custom="clr-namespace:HunterPie.GUIControls.Custom_Controls"
-             xmlns:System="clr-namespace:System;assembly=mscorlib" 
+             xmlns:System="clr-namespace:System;assembly=mscorlib"
              DataContext="{StaticResource Localization}">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -299,6 +299,10 @@
                             <TextBlock TextWrapping="Wrap" Text="{Binding Mode=OneTime, XPath=/Strings/Client/Settings/String[@ID\=\'STATIC_MONSTER_AILMENT_TIMER_STRING_FORMAT\']/@Name}" FontFamily="Segoe UI Light" Foreground="#FFF1F1F1" Canvas.Left="320" Canvas.Top="3" FontSize="16" Padding="0,0,10,0"/>
                             <TextBox x:Name="AilmentTimerTextFormat" TextWrapping="Wrap" Background="{x:Null}" Foreground="#FF9E9D9D" BorderBrush="#FFABADB3" BorderThickness="0,0,0,1" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"/>
                         </DockPanel>
+                        <!-- <DockPanel Margin="10, 0, 10, 5" ToolTip="{Binding Mode=OneTime, XPath=/Strings/Client/Settings/String[@ID\=\'ENABLE_MONSTER_WIDGET_HIDE_HEALTH\']/@Name}"> -->
+                        <!--     <TextBlock TextWrapping="Wrap" Text="{Binding Mode=OneTime, XPath=/Strings/Client/Settings/String[@ID\=\'ENABLE_MONSTER_WIDGET_HIDE_HEALTH\']/@Name}" FontFamily="Segoe UI" Foreground="#FFF1F1F1" Canvas.Left="320" Canvas.Top="3" FontSize="16" Padding="0,0, 10, 0"/> -->
+                        <!--     <TextBox x:Name="HideHealthFormat" TextWrapping="Wrap" Background="{x:Null}" Foreground="#FF9E9D9D" BorderBrush="#FFABADB3" BorderThickness="0, 0, 0, 1" HorizontalContentAlignment="Center" VerticalContentAlignment="Stretch"/> -->
+                        <!-- </DockPanel> -->
                         <DockPanel Height="28" ToolTip="{Binding Mode=OneTime, XPath=/Strings/Client/Settings/String[@ID\=\'STATIC_MONSTER_BAR_MODE_DESC\']/@Name}" Margin="10,0,10,5">
                             <TextBlock FontFamily="Segoe UI Light" Foreground="WhiteSmoke" Padding="0,0,10,0">
                                 <TextBlock.Text>
@@ -338,6 +342,7 @@
                                 <Binding Mode="OneTime" XPath="Settings/String[@ID='ENABLE_BREAKABLE_PARTS_DESC']/@Name"/>
                             </custom:Switcher.ToolTip>
                         </custom:Switcher>
+                        <custom:Switcher x:Name="switchEnableHealthHiding" Text="{Binding Mode=OneTime, XPath=/Strings/Client/Settings/String[@ID\=\'ENABLE_HIDE_MONSTER_HEALTH\']/@Name}" ToolTip="{Binding Mode=OneTime, XPath=/Strings/Client/Settings/String[@ID\=\'ENABLE_HIDE_MONSTER_HEALTH_DESC\']/@Name}" Margin="10, 0, 10, 5" RestartVisibility="Collapsed"/>
                         <custom:Switcher x:Name="switchEnableAilmentsColor" Text="{Binding Mode=OneTime, XPath=/Strings/Client/Settings/String[@ID\=\'ENABLE_AILMENTS_BAR_COLOR\']/@Name, FallbackValue='Enable ailments bar color'}" ToolTip="{Binding Mode=OneTime, XPath=/Strings/Client/Settings/String[@ID\=\'ENABLE_AILMENTS_BAR_COLOR_DESC\']/@Name}" Margin="10,0,10,5" RestartVisibility="Collapsed"/>
                         <custom:Switcher x:Name="switchEnableAilments" Margin="10,0,10,5" RestartVisibility="Collapsed" MouseLeftButtonDown="SwitchEnableAilments_MouseDown">
                             <custom:Switcher.Text>

--- a/HunterPie/GUIControls/NewSettingsWindow.xaml
+++ b/HunterPie/GUIControls/NewSettingsWindow.xaml
@@ -299,10 +299,6 @@
                             <TextBlock TextWrapping="Wrap" Text="{Binding Mode=OneTime, XPath=/Strings/Client/Settings/String[@ID\=\'STATIC_MONSTER_AILMENT_TIMER_STRING_FORMAT\']/@Name}" FontFamily="Segoe UI Light" Foreground="#FFF1F1F1" Canvas.Left="320" Canvas.Top="3" FontSize="16" Padding="0,0,10,0"/>
                             <TextBox x:Name="AilmentTimerTextFormat" TextWrapping="Wrap" Background="{x:Null}" Foreground="#FF9E9D9D" BorderBrush="#FFABADB3" BorderThickness="0,0,0,1" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"/>
                         </DockPanel>
-                        <!-- <DockPanel Margin="10, 0, 10, 5" ToolTip="{Binding Mode=OneTime, XPath=/Strings/Client/Settings/String[@ID\=\'ENABLE_MONSTER_WIDGET_HIDE_HEALTH\']/@Name}"> -->
-                        <!--     <TextBlock TextWrapping="Wrap" Text="{Binding Mode=OneTime, XPath=/Strings/Client/Settings/String[@ID\=\'ENABLE_MONSTER_WIDGET_HIDE_HEALTH\']/@Name}" FontFamily="Segoe UI" Foreground="#FFF1F1F1" Canvas.Left="320" Canvas.Top="3" FontSize="16" Padding="0,0, 10, 0"/> -->
-                        <!--     <TextBox x:Name="HideHealthFormat" TextWrapping="Wrap" Background="{x:Null}" Foreground="#FF9E9D9D" BorderBrush="#FFABADB3" BorderThickness="0, 0, 0, 1" HorizontalContentAlignment="Center" VerticalContentAlignment="Stretch"/> -->
-                        <!-- </DockPanel> -->
                         <DockPanel Height="28" ToolTip="{Binding Mode=OneTime, XPath=/Strings/Client/Settings/String[@ID\=\'STATIC_MONSTER_BAR_MODE_DESC\']/@Name}" Margin="10,0,10,5">
                             <TextBlock FontFamily="Segoe UI Light" Foreground="WhiteSmoke" Padding="0,0,10,0">
                                 <TextBlock.Text>

--- a/HunterPie/GUIControls/Settings.xaml.cs
+++ b/HunterPie/GUIControls/Settings.xaml.cs
@@ -84,6 +84,7 @@ namespace HunterPie.GUIControls
             settingsUI.switchEnableMonsterComponent.IsEnabled = settings.Overlay.MonstersComponent.Enabled;
             settingsUI.HealthTextFormat.Text = settings.Overlay.MonstersComponent.HealthTextFormat;
             settingsUI.PartHealthTextFormat.Text = settings.Overlay.MonstersComponent.PartTextFormat;
+            settingsUI.switchEnableHealthHiding.IsEnabled = settings.Overlay.MonstersComponent.HideHealthInformation;
             settingsUI.AilmentBuildUpTextFormat.Text = settings.Overlay.MonstersComponent.AilmentBuildupTextFormat;
             settingsUI.AilmentTimerTextFormat.Text = settings.Overlay.MonstersComponent.AilmentTimerTextFormat;
             settingsUI.switchUseLockon.IsEnabled = settings.Overlay.MonstersComponent.UseLockonInsteadOfPin;
@@ -96,7 +97,7 @@ namespace HunterPie.GUIControls
             settingsUI.MonstersPosition.Y = settings.Overlay.MonstersComponent.Position[1];
             settingsUI.switchEnableParts.IsEnabled = settings.Overlay.MonstersComponent.EnableMonsterParts;
             settingsUI.PartsCustomizer.IsEnabled = settingsUI.switchEnableParts.IsEnabled;
-            
+
             settingsUI.switchEnableAilments.IsEnabled = settings.Overlay.MonstersComponent.EnableMonsterAilments;
             settingsUI.AilmentsCustomizer.IsEnabled = settingsUI.switchEnableAilments.IsEnabled;
             foreach (Custom_Controls.Switcher switcher in settingsUI.AilmentsCustomizer.Children)
@@ -232,6 +233,7 @@ namespace HunterPie.GUIControls
             settings.Overlay.MonstersComponent.Enabled = settingsUI.switchEnableMonsterComponent.IsEnabled;
             settings.Overlay.MonstersComponent.HealthTextFormat = settingsUI.HealthTextFormat.Text;
             settings.Overlay.MonstersComponent.PartTextFormat = settingsUI.PartHealthTextFormat.Text;
+            settings.Overlay.MonstersComponent.HideHealthInformation = settingsUI.switchEnableHealthHiding.IsEnabled;
             settings.Overlay.MonstersComponent.AilmentBuildupTextFormat = settingsUI.AilmentBuildUpTextFormat.Text;
             settings.Overlay.MonstersComponent.AilmentTimerTextFormat = settingsUI.AilmentTimerTextFormat.Text;
             settings.Overlay.MonstersComponent.UseLockonInsteadOfPin = settingsUI.switchUseLockon.IsEnabled;

--- a/HunterPie/Hunterpie.xaml.cs
+++ b/HunterPie/Hunterpie.xaml.cs
@@ -100,9 +100,9 @@ namespace HunterPie
             CheckIfHunterPieOpen();
 
             AppDomain.CurrentDomain.UnhandledException += ExceptionLogger;
-            
+
             IsPlayerLoggedOn = false;
-            
+
             SetDPIAwareness();
             Buffers.Initialize(1024);
             Buffers.Add<byte>(64);
@@ -146,11 +146,11 @@ namespace HunterPie
             IEnumerable<Process> processes = Process.GetProcessesByName("HunterPie").Where(p => p.Id != instance.Id);
             foreach (Process p in processes) p.Kill();
         }
-            
+
 
         private void SetDPIAwareness()
         {
-            
+
             if (Environment.OSVersion.Version >= new Version(6, 3, 0))
             {
                 if (Environment.OSVersion.Version >= new Version(10, 0, 15063))
@@ -868,7 +868,7 @@ namespace HunterPie
                 TrayIcon.ContextMenu.MenuItems[1].Click -= OnTrayIconExitClick;
                 TrayIcon.Dispose();
             }
-            
+
             // Dispose stuff & stop scanning threads
             GameOverlay?.Dispose();
             if (MonsterHunter.IsActive) MonsterHunter?.StopScanning();
@@ -1023,7 +1023,7 @@ namespace HunterPie
             }
             if ((Keyboard.Modifiers & ModifierKeys.Control) != 0 && e.Key == Key.R)
             {
-                Reload();   
+                Reload();
             }
         }
         #endregion

--- a/HunterPie/Languages/en-us.xml
+++ b/HunterPie/Languages/en-us.xml
@@ -559,7 +559,7 @@
       <String ID="ENABLE_MONSTER_USE_LOCKON" Name="Use lockon instead of map pin to target monster"/>
       <String ID="ENABLE_MONSTER_USE_LOCKON_DESC" Name="If enabled, HunterPie will use the in-game monster lockon to select your target."/>
       <String ID="ENABLE_HIDE_MONSTER_HEALTH" Name="Hide Monster Bar health information"/>
-      <String ID="ENABLE_HIDE_MONSTER_HEALTH_DESC" Name="If enabled, the Monster Bar will not include HP details (total and remaining health, stamina and the capturable icon)."/>
+      <String ID="ENABLE_HIDE_MONSTER_HEALTH_DESC" Name="If enabled, the Monster Bar will not display HP-related details (total and remaining health, stamina, the capturable icon and enrage status and timer)."/>
       <String ID="STATIC_MONSTER_BAR_MODE" Name="Monster Bar Mode"/>
       <String ID="STATIC_MONSTER_BAR_MODE_DESC" Name="Changes the monster bar mode."/>
       <String ID="STATIC_MONSTER_BAR_MODE_0" Name="Show all monsters at once"/>

--- a/HunterPie/Languages/en-us.xml
+++ b/HunterPie/Languages/en-us.xml
@@ -477,7 +477,7 @@
       <String ID="MESSAGE_DISCORD_DISCONNECTED" Name="Closed connection to Discord"/>
       <String ID="MESSAGE_DISCORD_JOIN_REQUEST" Name="{Username} requested to join session."/>
       <String ID="MESSAGE_DISCORD_JOINING" Name="Joining session..."/>
-      
+
       <String ID="MESSAGE_MONSTER_DATA_LOAD" Name="Loaded monster data"/>
       <String ID="MESSAGE_ABNORMALITIES_DATA_LOAD" Name="Loaded abnormalities data"/>
       <String ID="MESSAGE_PLAYER_SCANNER_INITIALIZED" Name="Initialized player memory scanner"/>
@@ -558,6 +558,8 @@
       <String ID="STATIC_MONSTER_PART_HEALTH_STRING_FORMAT_DESC" Name="Text format for the monster part health."/>
       <String ID="ENABLE_MONSTER_USE_LOCKON" Name="Use lockon instead of map pin to target monster"/>
       <String ID="ENABLE_MONSTER_USE_LOCKON_DESC" Name="If enabled, HunterPie will use the in-game monster lockon to select your target."/>
+      <String ID="ENABLE_HIDE_MONSTER_HEALTH" Name="Hide Monster Bar health information"/>
+      <String ID="ENABLE_HIDE_MONSTER_HEALTH_DESC" Name="If enabled, the Monster Bar will not include HP details (total and remaining health, stamina and the capturable icon)."/>
       <String ID="STATIC_MONSTER_BAR_MODE" Name="Monster Bar Mode"/>
       <String ID="STATIC_MONSTER_BAR_MODE_DESC" Name="Changes the monster bar mode."/>
       <String ID="STATIC_MONSTER_BAR_MODE_0" Name="Show all monsters at once"/>

--- a/HunterPie/Languages/es-es.xml
+++ b/HunterPie/Languages/es-es.xml
@@ -530,8 +530,8 @@
       <String ID="STATIC_MONSTER_HEALTH_STRING_FORMAT_DESC" Name="Formato para la barra de vida del monstruo."/>
       <String ID="ENABLE_MONSTER_USE_LOCKON" Name="Fijar el monstruo para seleccionarlo"/>
       <String ID="ENABLE_MONSTER_USE_LOCKON_DESC" Name="Si lo activas, HunterPie tomará como objetivo al monstruo que tengas fijado (alterna entre seleccionar el monstruo mediante el mapa o mediante la función de fijado)."/>
-      <String ID="ENABLE_HIDE_MONSTER_HEALTH" Name="Esconder informacion de vida del monstruo"/>
-      <String ID="ENABLE_HIDE_MONSTER_HEALTH_DESC" Name="Activando esta opcion la Barra de informacion del Monstruo no mostrará detalles de la cantidad de vida del monstruo (incluye vida actual, vida total, resistencia actual y el icono de monstruo capturable)."/>
+      <String ID="ENABLE_HIDE_MONSTER_HEALTH" Name="Esconder información de vida del monstruo"/>
+      <String ID="ENABLE_HIDE_MONSTER_HEALTH_DESC" Name="Activando esta opción la Barra de información del Monstruo no mostrará detalles asociados la cantidad de vida del monstruo (incluye vida actual y total, resistencia, el icono de monstruo capturable y el estado y temporizador de ira)."/>
       <String ID="STATIC_MONSTER_BAR_MODE" Name="Modo de la barra de monstruo"/>
       <String ID="STATIC_MONSTER_BAR_MODE_DESC" Name="Cambia el modo de la barra del monstruo (la selección del monstruo objetivo se realiza desde el mapa, abajo a la izquierda)"/>
       <String ID="STATIC_MONSTER_BAR_MODE_0" Name="Mostrar todos los monstruos a la vez"/>

--- a/HunterPie/Languages/es-es.xml
+++ b/HunterPie/Languages/es-es.xml
@@ -530,6 +530,8 @@
       <String ID="STATIC_MONSTER_HEALTH_STRING_FORMAT_DESC" Name="Formato para la barra de vida del monstruo."/>
       <String ID="ENABLE_MONSTER_USE_LOCKON" Name="Fijar el monstruo para seleccionarlo"/>
       <String ID="ENABLE_MONSTER_USE_LOCKON_DESC" Name="Si lo activas, HunterPie tomará como objetivo al monstruo que tengas fijado (alterna entre seleccionar el monstruo mediante el mapa o mediante la función de fijado)."/>
+      <String ID="ENABLE_HIDE_MONSTER_HEALTH" Name="Esconder informacion de vida del monstruo"/>
+      <String ID="ENABLE_HIDE_MONSTER_HEALTH_DESC" Name="Activando esta opcion la Barra de informacion del Monstruo no mostrará detalles de la cantidad de vida del monstruo (incluye vida actual, vida total, resistencia actual y el icono de monstruo capturable)."/>
       <String ID="STATIC_MONSTER_BAR_MODE" Name="Modo de la barra de monstruo"/>
       <String ID="STATIC_MONSTER_BAR_MODE_DESC" Name="Cambia el modo de la barra del monstruo (la selección del monstruo objetivo se realiza desde el mapa, abajo a la izquierda)"/>
       <String ID="STATIC_MONSTER_BAR_MODE_0" Name="Mostrar todos los monstruos a la vez"/>


### PR DESCRIPTION
This PR aims to add a feature switch to allow for hiding of certain monster information that newer players might find spoils their first experiences with monsters.
When enabled, it will disable the following features:
  - Monster health and stamina text display
  - Monster health and stamina bar resizing (i.e. they will always remain at 100%)
  - Monster capture icon display
  - Monster enrage status and timer

### Changelist
- Added a setting for the new feature
- Used new setting to determine whether to perform relevant updates to the monster UI
- Refactored display logic of capture icon

### TODO
- String localization

Lastly, sorry about the whitespace changes, I didn't notice until it was too late. I do think they're positive changes, despite polluting the PR a bit, so I left them in.