### PR TITLE
Fixed clean.py and updated readme

### DIFF
--- a/HunterPie/clean.py
+++ b/HunterPie/clean.py
@@ -13,9 +13,14 @@ clean = [
 import os
 import shutil
 
+try:
+    os.mkdir("libs")
+except FileExistsError:
+    pass
+    
 for shit in os.listdir():
     if (shit.endswith(".dll") and shit not in ignore_dlls):
-        shutil.move(shit, f"libs\\{shit}")
+        shutil.move(shit, f"libs/{shit}")
     if (shit in shit_folders):
         shutil.rmtree(shit)
     if (shit[-4:] in clean):

--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ HunterPie is a modern and simple to use overlay with support for Discord Rich Pr
 
 - Delete HunterPie folder
 
+## Build instructions
+
+Visual Studio did not correctly install Python or NuGet for me... So if you need:
+- [Python](https://www.python.org/downloads/)
+- [NuGet](https://www.nuget.org/downloads)
+
+For the release build:
+
+```bash
+nuget restore HunterPie.sln
+msbuild HunterPie.sln -property:Configuration=Release
+```
+
+The apps will be in _{HunterPie|Update}/bin/Release_
+
 ## Features
 
 ### Core


### PR DESCRIPTION
When building the first time, libs/ doesn't exist, so this line throws an exception, causing the build to fail:
https://github.com/Haato3o/HunterPie/blob/2b306b2/HunterPie/clean.py#L18
```python
        shutil.move(shit, f"libs\\{shit}")
```

That makes for a shitty experience for a first time contributor. lol. So it's fixed.

Also updated the readme with build instructions. Might be useful for setting up CI in the future.