### PR TITLE
Added CI

### DIFF
--- a/.github/workflows/build-release-ci.yml
+++ b/.github/workflows/build-release-ci.yml
@@ -116,7 +116,7 @@ jobs:
 
   release:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     if: startsWith(needs.build.outputs.git_ref, 'v')
     
     steps:
@@ -136,17 +136,29 @@ jobs:
         mv HunterPie/bin/Release zip/HunterPie
         mv -f Update/bin/Release/* zip/HunterPie
         cd zip
-        zip -r HunterPie.zip HunterPie
-  
+        7z a -tzip HunterPie.zip HunterPie/* -r
+        
+    - name: Push to Nuget repo
+      run: |
+        nuget sources add -name "Github" \
+              -Source https://nuget.pkg.github.com/$GITHUB_REPOSITORY_OWNER/index.json \
+              -Username $GITHUB_REPOSITORY_OWNER \
+              -Password $GITHUB_TOKEN
+        nuget pack HunterPie.Core -Prop Configuration=Release -properties repo=$GITHUB_REPOSITORY
+        nuget pack HunterPie.UI -Prop Configuration=Release -properties repo=$GITHUB_REPOSITORY
+
+        for pkg in *.nupkg; do nuget push $pkg -Source "Github" -ApiKey $GITHUB_TOKEN -SkipDuplicate; done
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+
     - name: Update release with binaries
       # this is a workaround because actions/upload-release-asset isn't allowed multiple times
       # this looks neater, though
-      # https://cli.github.com/manual/gh_release_create
+      # https://hub.github.com/hub-release.1.html
       run: |
-        gh release create $GIT_REF -t "Release $GIT_REF" \
-          zip/HunterPie.zip \
-          HunterPie.Core/bin/Release/HunterPie.Core.dll \
-          HunterPie.UI/bin/Release/HunterPie.UI.dll
+        hub release create $GIT_REF --message "Release $GIT_REF"
+        hub release edit   $GIT_REF -m "" -a zip/HunterPie.zip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GIT_REF: ${{ needs.build.outputs.git_ref }}

--- a/.github/workflows/build-release-ci.yml
+++ b/.github/workflows/build-release-ci.yml
@@ -116,7 +116,7 @@ jobs:
 
   release:
     needs: build
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     if: startsWith(needs.build.outputs.git_ref, 'v')
     
     steps:
@@ -130,22 +130,23 @@ jobs:
       with:
         name: Hunter Pie Release
 
-    # TODO: Pack them together
     - name: Zip Hunter Pie & Update
       run: |
         mkdir zip
         mv HunterPie/bin/Release zip/HunterPie
         mv -f Update/bin/Release/* zip/HunterPie
         cd zip
-        7z a -tzip HunterPie.zip HunterPie/* -r
+        zip -r HunterPie.zip HunterPie
   
     - name: Update release with binaries
       # this is a workaround because actions/upload-release-asset isn't allowed multiple times
-      # https://hub.github.com/hub-release.1.html
+      # this looks neater, though
+      # https://cli.github.com/manual/gh_release_create
       run: |
-        hub release create $GIT_REF --message "Release $GIT_REF"
-        hub release edit   $GIT_REF -m "" -a zip/HunterPie.zip
-        hub release edit   $GIT_REF -m "" -a HunterPie.Core/bin/Release/HunterPie.Core.dll
+        gh release create $GIT_REF -t "Release $GIT_REF" \
+          zip/HunterPie.zip \
+          HunterPie.Core/bin/Release/HunterPie.Core.dll \
+          HunterPie.UI/bin/Release/HunterPie.UI.dll
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GIT_REF: ${{ needs.build.outputs.git_ref }}

--- a/.github/workflows/build-release-ci.yml
+++ b/.github/workflows/build-release-ci.yml
@@ -159,6 +159,8 @@ jobs:
       run: |
         hub release create $GIT_REF --message "Release $GIT_REF"
         hub release edit   $GIT_REF -m "" -a zip/HunterPie.zip
+        hub release edit   $GIT_REF -m "" -a HunterPie.Core/bin/Release/HunterPie.Core.dll
+        hub release edit   $GIT_REF -m "" -a HunterPie.UI/bin/Release/HunterPie.UI.dll
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GIT_REF: ${{ needs.build.outputs.git_ref }}

--- a/.github/workflows/dotnet-core-desktop.yml
+++ b/.github/workflows/dotnet-core-desktop.yml
@@ -91,6 +91,15 @@ jobs:
       run: msbuild $env:Solution_Name -m /p:Configuration=$env:Configuration
       env:
         Configuration: ${{ matrix.configuration }}
+  
+    # Upload the release builds for next step
+    - name: Upload build artifacts
+      if: matrix.configuration == 'Release'
+      uses: actions/upload-artifact@v2
+      with:
+        name: MSIX Package
+        path: ./**/bin/Release/*
+
 
     # # Decode the base 64 encoded pfx and save the Signing_Certificate
     # - name: Decode the pfx

--- a/.github/workflows/dotnet-core-desktop.yml
+++ b/.github/workflows/dotnet-core-desktop.yml
@@ -130,21 +130,21 @@ jobs:
       with:
         name: Hunter Pie Release
 
-    - name: Zip Hunter Pie
+    # TODO: Pack them together
+    - name: Zip Hunter Pie & Update
       run: |
-        cd HunterPie/bin/Release
-        7z a -tzip HunterPie.zip * -r
-
-    - name: Zip Update
-      run: |
-        cd Update/bin/Release
-        7z -tzip a Update.zip * -r
+        mkdir zip
+        mv HunterPie/bin/Release zip/HunterPie
+        mv -f Update/bin/Release/* zip/HunterPie
+        cd zip
+        7z a -tzip HunterPie.zip HunterPie/* -r
   
     - name: Update release with binaries
+      # this is a workaround because actions/upload-release-asset isn't allowed multiple times
+      # https://hub.github.com/hub-release.1.html
       run: |
         hub release create $GIT_REF --message "Release $GIT_REF"
-        hub release edit   $GIT_REF -m "" -a HunterPie/bin/Release/HunterPie.zip
-        hub release edit   $GIT_REF -m "" -a Update/bin/Release/Update.zip
+        hub release edit   $GIT_REF -m "" -a zip/HunterPie.zip
         hub release edit   $GIT_REF -m "" -a HunterPie.Core/bin/Release/HunterPie.Core.dll
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dotnet-core-desktop.yml
+++ b/.github/workflows/dotnet-core-desktop.yml
@@ -41,8 +41,8 @@ name: .NET Core Desktop
 on:
   push:
     branches: [ development ]
-  pull_request:
-    branches: [ development ]
+  # pull_request:
+  #   branches: [ development ]
 
 jobs:
 
@@ -56,10 +56,10 @@ jobs:
                              # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
 
     env:
-      Solution_Name: your-solution-name                         # Replace with your solution name, i.e. MyWpfApp.sln.
-      Test_Project_Path: your-test-project-path                 # Replace with the path to your test project, i.e. MyWpfApp.Tests\MyWpfApp.Tests.csproj.
-      Wap_Project_Directory: your-wap-project-directory-name    # Replace with the Wap project directory relative to the solution, i.e. MyWpfApp.Package.
-      Wap_Project_Path: your-wap-project-path                   # Replace with the path to your Wap project, i.e. MyWpf.App.Package\MyWpfApp.Package.wapproj.
+      Solution_Name: HunterPie.sln                                # Replace with your solution name, i.e. MyWpfApp.sln.
+      # Test_Project_Path: your-test-project-path                 # Replace with the path to your test project, i.e. MyWpfApp.Tests\MyWpfApp.Tests.csproj.
+      # Wap_Project_Directory: your-wap-project-directory-name    # Replace with the Wap project directory relative to the solution, i.e. MyWpfApp.Package.
+      # Wap_Project_Path: your-wap-project-path                   # Replace with the path to your Wap project, i.e. MyWpf.App.Package\MyWpfApp.Package.wapproj.
 
     steps:
     - name: Checkout
@@ -75,41 +75,46 @@ jobs:
 
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@2008f912f56e61277eefaac6d1888b750582aa16
+      uses: microsoft/setup-msbuild@v1.0.2
 
-    # Execute all unit tests in the solution
-    - name: Execute unit tests
-      run: dotnet test
+    # # Execute all unit tests in the solution
+    # - name: Execute unit tests
+    #   run: dotnet test
 
     # Restore the application to populate the obj folder with RuntimeIdentifiers
-    - name: Restore the application
-      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
+    - name: Restore the applications
+      run: msbuild $env:Solution_Name -m /t:Restore /p:Configuration=$env:Configuration
       env:
         Configuration: ${{ matrix.configuration }}
 
-    # Decode the base 64 encoded pfx and save the Signing_Certificate
-    - name: Decode the pfx
-      run: |
-        $pfx_cert_byte = [System.Convert]::FromBase64String("${{ secrets.Base64_Encoded_Pfx }}")
-        $certificatePath = Join-Path -Path $env:Wap_Project_Directory -ChildPath GitHubActionsWorkflow.pfx
-        [IO.File]::WriteAllBytes("$certificatePath", $pfx_cert_byte)
-
-    # Create the app package by building and packaging the Windows Application Packaging project
-    - name: Create the app package
-      run: msbuild $env:Wap_Project_Path /p:Configuration=$env:Configuration /p:UapAppxPackageBuildMode=$env:Appx_Package_Build_Mode /p:AppxBundle=$env:Appx_Bundle /p:PackageCertificateKeyFile=GitHubActionsWorkflow.pfx /p:PackageCertificatePassword=${{ secrets.Pfx_Key }}
+    - name: Build the apps
+      run: msbuild $env:Solution_Name -m /p:Configuration=$env:Configuration
       env:
-        Appx_Bundle: Always
-        Appx_Bundle_Platforms: x86|x64
-        Appx_Package_Build_Mode: StoreUpload
         Configuration: ${{ matrix.configuration }}
 
-    # Remove the pfx
-    - name: Remove the pfx
-      run: Remove-Item -path $env:Wap_Project_Directory\$env:Signing_Certificate
+    # # Decode the base 64 encoded pfx and save the Signing_Certificate
+    # - name: Decode the pfx
+    #   run: |
+    #     $pfx_cert_byte = [System.Convert]::FromBase64String("${{ secrets.Base64_Encoded_Pfx }}")
+    #     $certificatePath = Join-Path -Path $env:Wap_Project_Directory -ChildPath GitHubActionsWorkflow.pfx
+    #     [IO.File]::WriteAllBytes("$certificatePath", $pfx_cert_byte)
 
-    # Upload the MSIX package: https://github.com/marketplace/actions/upload-artifact
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: MSIX Package
-        path: ${{ env.Wap_Project_Directory }}\AppPackages
+    # # Create the app package by building and packaging the Windows Application Packaging project
+    # - name: Create the app package
+    #   run: msbuild $env:Wap_Project_Path /p:Configuration=$env:Configuration /p:UapAppxPackageBuildMode=$env:Appx_Package_Build_Mode /p:AppxBundle=$env:Appx_Bundle /p:PackageCertificateKeyFile=GitHubActionsWorkflow.pfx /p:PackageCertificatePassword=${{ secrets.Pfx_Key }}
+    #   env:
+    #     Appx_Bundle: Always
+    #     Appx_Bundle_Platforms: x86|x64
+    #     Appx_Package_Build_Mode: StoreUpload
+    #     Configuration: ${{ matrix.configuration }}
+
+    # # Remove the pfx
+    # - name: Remove the pfx
+    #   run: Remove-Item -path $env:Wap_Project_Directory\$env:Signing_Certificate
+
+    # # Upload the MSIX package: https://github.com/marketplace/actions/upload-artifact
+    # - name: Upload build artifacts
+    #   uses: actions/upload-artifact@v2
+    #   with:
+    #     name: MSIX Package
+    #     path: ${{ env.Wap_Project_Directory }}\AppPackages

--- a/.github/workflows/dotnet-core-desktop.yml
+++ b/.github/workflows/dotnet-core-desktop.yml
@@ -1,0 +1,115 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow will build, test, sign and package a WPF or Windows Forms desktop application
+# built on .NET Core.
+# To learn how to migrate your existing application to .NET Core,
+# refer to https://docs.microsoft.com/en-us/dotnet/desktop-wpf/migration/convert-project-from-net-framework
+#
+# To configure this workflow:
+#
+# 1. Configure environment variables
+# GitHub sets default environment variables for every workflow run.
+# Replace the variables relative to your project in the "env" section below.
+#
+# 2. Signing
+# Generate a signing certificate in the Windows Application
+# Packaging Project or add an existing signing certificate to the project.
+# Next, use PowerShell to encode the .pfx file using Base64 encoding
+# by running the following Powershell script to generate the output string:
+#
+# $pfx_cert = Get-Content '.\SigningCertificate.pfx' -Encoding Byte
+# [System.Convert]::ToBase64String($pfx_cert) | Out-File 'SigningCertificate_Encoded.txt'
+#
+# Open the output file, SigningCertificate_Encoded.txt, and copy the
+# string inside. Then, add the string to the repo as a GitHub secret
+# and name it "Base64_Encoded_Pfx."
+# For more information on how to configure your signing certificate for
+# this workflow, refer to https://github.com/microsoft/github-actions-for-desktop-apps#signing
+#
+# Finally, add the signing certificate password to the repo as a secret and name it "Pfx_Key".
+# See "Build the Windows Application Packaging project" below to see how the secret is used.
+#
+# For more information on GitHub Actions, refer to https://github.com/features/actions
+# For a complete CI/CD sample to get started with GitHub Action workflows for Desktop Applications,
+# refer to https://github.com/microsoft/github-actions-for-desktop-apps
+
+name: .NET Core Desktop
+
+on:
+  push:
+    branches: [ development ]
+  pull_request:
+    branches: [ development ]
+
+jobs:
+
+  build:
+
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
+
+    runs-on: windows-latest  # For a list of available runner types, refer to
+                             # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+
+    env:
+      Solution_Name: your-solution-name                         # Replace with your solution name, i.e. MyWpfApp.sln.
+      Test_Project_Path: your-test-project-path                 # Replace with the path to your test project, i.e. MyWpfApp.Tests\MyWpfApp.Tests.csproj.
+      Wap_Project_Directory: your-wap-project-directory-name    # Replace with the Wap project directory relative to the solution, i.e. MyWpfApp.Package.
+      Wap_Project_Path: your-wap-project-path                   # Replace with the path to your Wap project, i.e. MyWpf.App.Package\MyWpfApp.Package.wapproj.
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    # Install the .NET Core workload
+    - name: Install .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.101
+
+    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@2008f912f56e61277eefaac6d1888b750582aa16
+
+    # Execute all unit tests in the solution
+    - name: Execute unit tests
+      run: dotnet test
+
+    # Restore the application to populate the obj folder with RuntimeIdentifiers
+    - name: Restore the application
+      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
+      env:
+        Configuration: ${{ matrix.configuration }}
+
+    # Decode the base 64 encoded pfx and save the Signing_Certificate
+    - name: Decode the pfx
+      run: |
+        $pfx_cert_byte = [System.Convert]::FromBase64String("${{ secrets.Base64_Encoded_Pfx }}")
+        $certificatePath = Join-Path -Path $env:Wap_Project_Directory -ChildPath GitHubActionsWorkflow.pfx
+        [IO.File]::WriteAllBytes("$certificatePath", $pfx_cert_byte)
+
+    # Create the app package by building and packaging the Windows Application Packaging project
+    - name: Create the app package
+      run: msbuild $env:Wap_Project_Path /p:Configuration=$env:Configuration /p:UapAppxPackageBuildMode=$env:Appx_Package_Build_Mode /p:AppxBundle=$env:Appx_Bundle /p:PackageCertificateKeyFile=GitHubActionsWorkflow.pfx /p:PackageCertificatePassword=${{ secrets.Pfx_Key }}
+      env:
+        Appx_Bundle: Always
+        Appx_Bundle_Platforms: x86|x64
+        Appx_Package_Build_Mode: StoreUpload
+        Configuration: ${{ matrix.configuration }}
+
+    # Remove the pfx
+    - name: Remove the pfx
+      run: Remove-Item -path $env:Wap_Project_Directory\$env:Signing_Certificate
+
+    # Upload the MSIX package: https://github.com/marketplace/actions/upload-artifact
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: MSIX Package
+        path: ${{ env.Wap_Project_Directory }}\AppPackages

--- a/.github/workflows/dotnet-core-desktop.yml
+++ b/.github/workflows/dotnet-core-desktop.yml
@@ -36,13 +36,19 @@
 # For a complete CI/CD sample to get started with GitHub Action workflows for Desktop Applications,
 # refer to https://github.com/microsoft/github-actions-for-desktop-apps
 
-name: .NET Core Desktop
+name: Hunter Pie CI
 
 on:
   push:
-    branches: [ development ]
+    branches: [ master, development ]
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
   # pull_request:
   #   branches: [ development ]
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
 
@@ -61,11 +67,17 @@ jobs:
       # Wap_Project_Directory: your-wap-project-directory-name    # Replace with the Wap project directory relative to the solution, i.e. MyWpfApp.Package.
       # Wap_Project_Path: your-wap-project-path                   # Replace with the path to your Wap project, i.e. MyWpf.App.Package\MyWpfApp.Package.wapproj.
 
+    outputs:
+      git_ref: ${{ steps.set_ref.outputs.git_ref }}
+
     steps:
     - name: Checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+
+    - id: set_ref
+      run: echo "::set-output name=git_ref::${GITHUB_REF##*/}"
 
     # Install the .NET Core workload
     - name: Install .NET Core
@@ -83,47 +95,57 @@ jobs:
 
     # Restore the application to populate the obj folder with RuntimeIdentifiers
     - name: Restore the applications
+      shell: pwsh
       run: msbuild $env:Solution_Name -m /t:Restore /p:Configuration=$env:Configuration
       env:
         Configuration: ${{ matrix.configuration }}
 
     - name: Build the apps
+      shell: pwsh
       run: msbuild $env:Solution_Name -m /p:Configuration=$env:Configuration
       env:
         Configuration: ${{ matrix.configuration }}
   
-    # Upload the release builds for next step
+    # Upload the builds for next job and debugging
     - name: Upload build artifacts
-      if: matrix.configuration == 'Release'
       uses: actions/upload-artifact@v2
       with:
-        name: MSIX Package
-        path: ./**/bin/Release/*
+        # Don't know if this should be unique to the tag/branch/PR
+        name: Hunter Pie ${{ matrix.configuration }}
+        path: ./**/bin/*
 
+  release:
+    needs: build
+    runs-on: windows-latest
+    if: startsWith(needs.build.outputs.git_ref, 'v')
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
-    # # Decode the base 64 encoded pfx and save the Signing_Certificate
-    # - name: Decode the pfx
-    #   run: |
-    #     $pfx_cert_byte = [System.Convert]::FromBase64String("${{ secrets.Base64_Encoded_Pfx }}")
-    #     $certificatePath = Join-Path -Path $env:Wap_Project_Directory -ChildPath GitHubActionsWorkflow.pfx
-    #     [IO.File]::WriteAllBytes("$certificatePath", $pfx_cert_byte)
+    - name: Download build artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: Hunter Pie Release
 
-    # # Create the app package by building and packaging the Windows Application Packaging project
-    # - name: Create the app package
-    #   run: msbuild $env:Wap_Project_Path /p:Configuration=$env:Configuration /p:UapAppxPackageBuildMode=$env:Appx_Package_Build_Mode /p:AppxBundle=$env:Appx_Bundle /p:PackageCertificateKeyFile=GitHubActionsWorkflow.pfx /p:PackageCertificatePassword=${{ secrets.Pfx_Key }}
-    #   env:
-    #     Appx_Bundle: Always
-    #     Appx_Bundle_Platforms: x86|x64
-    #     Appx_Package_Build_Mode: StoreUpload
-    #     Configuration: ${{ matrix.configuration }}
+    - name: Zip Hunter Pie
+      run: |
+        cd HunterPie/bin/Release
+        7z a -tzip HunterPie.zip * -r
 
-    # # Remove the pfx
-    # - name: Remove the pfx
-    #   run: Remove-Item -path $env:Wap_Project_Directory\$env:Signing_Certificate
-
-    # # Upload the MSIX package: https://github.com/marketplace/actions/upload-artifact
-    # - name: Upload build artifacts
-    #   uses: actions/upload-artifact@v2
-    #   with:
-    #     name: MSIX Package
-    #     path: ${{ env.Wap_Project_Directory }}\AppPackages
+    - name: Zip Update
+      run: |
+        cd Update/bin/Release
+        7z -tzip a Update.zip * -r
+  
+    - name: Update release with binaries
+      run: |
+        hub release create $GIT_REF --message "Release $GIT_REF"
+        hub release edit   $GIT_REF -m "" -a HunterPie/bin/Release/HunterPie.zip
+        hub release edit   $GIT_REF -m "" -a Update/bin/Release/Update.zip
+        hub release edit   $GIT_REF -m "" -a HunterPie.Core/bin/Release/HunterPie.Core.dll
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GIT_REF: ${{ needs.build.outputs.git_ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ docs/node_modules
 # Scripts to turn .cs into markdown
 dump
 dump.py
+
+*.nupkg

--- a/HunterPie.Core/HunterPie.Core.nuspec
+++ b/HunterPie.Core/HunterPie.Core.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$id$</id>
-    <version>1.3.99</version>
+    <version>1.0.3-99</version>
     <title>$title$</title>
     <authors>Haato</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -10,6 +10,7 @@
     <projectUrl>https://github.com/Haato3o/HunterPie</projectUrl>
     <repository type="git" url="https://github.com/$repo$.git" />
     <releaseNotes>First package since Core library was moved from the main application</releaseNotes>
+    <description>Hunter Pie core library</description>
     <copyright>$copyright$</copyright>
     <dependencies>
       <group targetFramework=".NETFramework4.8" />

--- a/HunterPie.Core/HunterPie.Core.nuspec
+++ b/HunterPie.Core/HunterPie.Core.nuspec
@@ -2,15 +2,17 @@
 <package >
   <metadata>
     <id>$id$</id>
-    <version>$version$</version>
+    <version>1.3.99</version>
     <title>$title$</title>
-    <authors>$author$</authors>
+    <authors>Haato</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/Haato3o/HunterPie</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/Haato3o/HunterPie/master/HunterPie/LOGO_HunterPie.ico</iconUrl>
-    <description>$description$</description>
+    <repository type="git" url="https://github.com/$repo$.git" />
     <releaseNotes>First package since Core library was moved from the main application</releaseNotes>
     <copyright>$copyright$</copyright>
+    <dependencies>
+      <group targetFramework=".NETFramework4.8" />
+    </dependencies>
   </metadata>
 </package>

--- a/HunterPie.Core/HunterPie.Core.nuspec
+++ b/HunterPie.Core/HunterPie.Core.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$title$</title>
+    <authors>$author$</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/Haato3o/HunterPie</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/Haato3o/HunterPie/master/HunterPie/LOGO_HunterPie.ico</iconUrl>
+    <description>$description$</description>
+    <releaseNotes>First package since Core library was moved from the main application</releaseNotes>
+    <copyright>$copyright$</copyright>
+  </metadata>
+</package>

--- a/HunterPie.Core/Properties/AssemblyInfo.cs
+++ b/HunterPie.Core/Properties/AssemblyInfo.cs
@@ -8,9 +8,9 @@ using System.Windows;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("HunterPie.Core")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Core library for Hunter Pie and plugins")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Haato")]
 [assembly: AssemblyProduct("HunterPie.Core")]
 [assembly: AssemblyCopyright("Copyright ©  2020")]
 [assembly: AssemblyTrademark("")]

--- a/HunterPie.UI/HunterPie.UI.nuspec
+++ b/HunterPie.UI/HunterPie.UI.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$title$</title>
+    <authors>$author$</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/Haato3o/HunterPie</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/Haato3o/HunterPie/master/HunterPie/LOGO_HunterPie.ico</iconUrl>
+    <description>$description$</description>
+    <releaseNotes>First package since UI library was moved from the main application</releaseNotes>
+    <copyright>$copyright$</copyright>
+  </metadata>
+</package>

--- a/HunterPie.UI/HunterPie.UI.nuspec
+++ b/HunterPie.UI/HunterPie.UI.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$id$</id>
-    <version>1.3.99</version>
+    <version>1.0.3-99</version>
     <title>$title$</title>
     <authors>Haato</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -10,6 +10,7 @@
     <projectUrl>https://github.com/Haato3o/HunterPie</projectUrl>
     <repository type="git" url="https://github.com/$repo$.git" />
     <releaseNotes>First package since UI library was moved from the main application</releaseNotes>
+    <description>Hunter Pie UI library</description>
     <copyright>$copyright$</copyright>
     <dependencies>
       <group targetFramework=".NETFramework4.8" />

--- a/HunterPie.UI/HunterPie.UI.nuspec
+++ b/HunterPie.UI/HunterPie.UI.nuspec
@@ -2,15 +2,17 @@
 <package >
   <metadata>
     <id>$id$</id>
-    <version>$version$</version>
+    <version>1.3.99</version>
     <title>$title$</title>
-    <authors>$author$</authors>
+    <authors>Haato</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/Haato3o/HunterPie</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/Haato3o/HunterPie/master/HunterPie/LOGO_HunterPie.ico</iconUrl>
-    <description>$description$</description>
+    <repository type="git" url="https://github.com/$repo$.git" />
     <releaseNotes>First package since UI library was moved from the main application</releaseNotes>
     <copyright>$copyright$</copyright>
+    <dependencies>
+      <group targetFramework=".NETFramework4.8" />
+    </dependencies>
   </metadata>
 </package>

--- a/HunterPie.UI/Properties/AssemblyInfo.cs
+++ b/HunterPie.UI/Properties/AssemblyInfo.cs
@@ -6,9 +6,9 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("HunterPie.UI")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Library for Hunter Pie UI elements")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Haato")]
 [assembly: AssemblyProduct("HunterPie.UI")]
 [assembly: AssemblyCopyright("Copyright ©  2020")]
 [assembly: AssemblyTrademark("")]


### PR DESCRIPTION
To see it in action, check out my last [2-4 builds](https://github.com/ForksKnivesAndSpoons/HunterPie/actions) and my [releases](https://github.com/ForksKnivesAndSpoons/HunterPie/releases).

- Builds on `master`, `develop`, and tags that start with v.
- Only publishes a release if a tag matching v*, is pushed. i.e. `v1.0`, `v20.15.10`
  - ...something like `vortex` will also trigger it. Could use a different prefix
- Didn't notice any tests, so skipped adding a test step, though it would be useful to have tests run on PRs
- I believe this config needs to be on your default branch to activate, so it may not start building for you until you merge to master.
  - Alternatively, I can cherry-pick these commits...

To upload these files to Heroku, we can do something like this:
```yaml
  serve:
    runs-on: ubuntu-latest
    steps:    - name: Login to Heroku Container registry
      env: 
        HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
    # Upload to Heroku command
    # ...
```

We'd just need to upload the zip as an artifact before finishing the release job because windows-latest doesn't have heroku cli installed... But ubuntu-latest does. And you'd have to define `HEROKU_API_KEY` in your _Settings->Secrets_.

1. [Inspiration for Heroku](https://gist.githubusercontent.com/joenash/cd2bba59ee710507f5b63cec1104346f/raw/6e5d8de938fdd99e9100b0ed9e9381d2ab90912b/workflow-3.yml)
2. [Heroku CLI](https://devcenter.heroku.com/articles/using-the-cli)
3. [Available environments](https://github.com/actions/virtual-environments/blob/main/README.md)