### PR TITLE
Preserving plugin settings

### DIFF
--- a/HunterPie.Core/Core/Local/Jobs/HuntingHorn.cs
+++ b/HunterPie.Core/Core/Local/Jobs/HuntingHorn.cs
@@ -208,7 +208,7 @@ namespace HunterPie.Core.Jobs
         public delegate void HuntingHornSongEvents(object source, HuntingHornSongEventArgs args);
         public delegate void HuntingHornSongCastEvents(object source, HuntingHornSongCastEventArgs args);
 
-        public event HuntingHornEvents OnSongsListUpdate;
+        // public event HuntingHornEvents OnSongsListUpdate;
         public event HuntingHornEvents OnNoteColorUpdate;
 
         public event HuntingHornNoteEvents OnNoteQueueUpdate;

--- a/HunterPie.Core/HunterPie.Core.csproj
+++ b/HunterPie.Core/HunterPie.Core.csproj
@@ -158,6 +158,7 @@
     <Compile Include="Core\Monsters\Part.cs" />
     <Compile Include="Core\Party\Member.cs" />
     <Compile Include="Core\Party\Party.cs" />
+    <Compile Include="HunterPie.Plugins\PluginSettingsHelper.cs" />
     <Compile Include="Logger\Debugger.cs" />
     <Compile Include="HunterPie.Plugins\IPlugin.cs" />
     <Compile Include="HunterPie.Plugins\PluginInformation.cs" />

--- a/HunterPie.Core/HunterPie.Plugins/PluginPackage.cs
+++ b/HunterPie.Core/HunterPie.Plugins/PluginPackage.cs
@@ -1,4 +1,6 @@
-﻿namespace HunterPie.Plugins
+﻿using Newtonsoft.Json.Linq;
+
+namespace HunterPie.Plugins
 {
     /// <summary>
     /// A package structure with all the plugin information
@@ -8,6 +10,7 @@
         public IPlugin plugin;
         public PluginInformation information;
         public PluginSettings settings;
+        public JObject settingsJson;
         public string path;
     }
 }

--- a/HunterPie.Core/HunterPie.Plugins/PluginSettingsHelper.cs
+++ b/HunterPie.Core/HunterPie.Plugins/PluginSettingsHelper.cs
@@ -1,0 +1,26 @@
+﻿using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace HunterPie.Plugins
+{
+    public class PluginSettingsHelper
+    {
+        public static PluginSettings GetPluginSettings(JObject json)
+        {
+            if (json.Properties().Count() == 0)
+            {
+                return new PluginSettings();
+            }
+            else
+            {
+                return json.ToObject<PluginSettings>();
+            }
+        }
+
+        public static void mergePluginSettings(JObject json, PluginSettings overrides)
+        {
+            json.Merge(JObject.FromObject(overrides));
+        }
+
+    }
+}

--- a/HunterPie.CoreTests/HunterPie.CoreTests.csproj
+++ b/HunterPie.CoreTests/HunterPie.CoreTests.csproj
@@ -10,6 +10,11 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions.Json" Version="5.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HunterPie.CoreTests/HunterPie.Plugins/PluginSettingsHelperTest.cs
+++ b/HunterPie.CoreTests/HunterPie.Plugins/PluginSettingsHelperTest.cs
@@ -1,0 +1,77 @@
+﻿using NUnit.Framework;
+using HunterPie.Plugins;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json.Linq;
+using FluentAssertions;
+using FluentAssertions.Json;
+
+namespace HunterPie.Plugins.Tests
+{
+    [TestFixture()]
+    public class PluginSettingsHelperTest
+    {
+        private static JObject emptyJson = new JObject();
+        private static JObject disabledJson = JObject.Parse(@"{'IsEnabled': false}");
+        private static JObject extraJson = JObject.Parse(@"{
+            'IsEnabled': false,
+            'SomeOtherProperty': 'Some value'
+        }");
+        private static JObject extraJson2 = JObject.Parse(@"{
+            'IsEnabled': false,
+            'SomeOtherProperty': 'Some value'
+        }");
+        private static JObject extraJsonEnabled = JObject.Parse(@"{
+            'IsEnabled': true,
+            'SomeOtherProperty': 'Some value'
+        }");
+
+        [Test, TestCaseSource("GetPluginSettingsData")]
+        public void GetPluginSettingsTest(JObject json, PluginSettings expectedSettings)
+        {
+            var actualSettings = PluginSettingsHelper.GetPluginSettings(json);
+            actualSettings.Should().BeEquivalentTo(expectedSettings);
+        }
+
+        private static IEnumerable<TestCaseData> GetPluginSettingsData()
+        {
+            var enabled = new PluginSettings();
+            var disabled = new PluginSettings();
+            disabled.IsEnabled = false;
+
+            yield return new TestCaseData(emptyJson, enabled)
+                .SetName("Should return default PluginSettings if given empty JSON");
+            yield return new TestCaseData(disabledJson, disabled)
+                .SetName("Should return matching PluginSettings");
+            yield return new TestCaseData(extraJson, disabled)
+                .SetName("Should return PluginSettings extracted from JSON");
+        }
+
+        [Test, TestCaseSource("MergePluginSettingsData")]
+        public void MergePluginSettingsTest(JObject json, PluginSettings overrides, JObject expectedJson)
+        {
+            PluginSettingsHelper.mergePluginSettings(json, overrides);
+            json.Should().BeEquivalentTo(expectedJson);
+        }
+
+        private static IEnumerable<TestCaseData> MergePluginSettingsData()
+        {
+            var enabled = new PluginSettings();
+            var disabled = new PluginSettings();
+            disabled.IsEnabled = false;
+
+            // Need to make these here because merge modifies the instance...
+            var emptyJson = new JObject();
+            var extraJson = JObject.Parse(@"{
+                'IsEnabled': false,
+                'SomeOtherProperty': 'Some value'
+            }");
+
+            yield return new TestCaseData(emptyJson, disabled, disabledJson)
+                .SetName("Should populate empty settings with default");
+            yield return new TestCaseData(extraJson, enabled, extraJsonEnabled)
+                .SetName("Should override settings but keep the settings that don't have overrides");
+        }
+    }
+}

--- a/HunterPie.UI/GUI/Widgets/MantleTimer.xaml.cs
+++ b/HunterPie.UI/GUI/Widgets/MantleTimer.xaml.cs
@@ -207,7 +207,7 @@ namespace HunterPie.GUI.Widgets
         }));
 
 
-        public void ScaleWidget(double NewScaleX, double NewScaleY)
+        override public void ScaleWidget(double NewScaleX, double NewScaleY)
         {
             if (NewScaleX <= 0.2) return;
             Width = BaseWidth * NewScaleX;

--- a/HunterPie/GUIControls/Custom Controls/PluginContainer.xaml.cs
+++ b/HunterPie/GUIControls/Custom Controls/PluginContainer.xaml.cs
@@ -96,7 +96,8 @@ namespace HunterPie.GUIControls.Custom_Controls
             e.Handled = true;
             IsPluginEnabled = !IsPluginEnabled;
             pluginPackage.settings.IsEnabled = IsPluginEnabled;
-            PluginManager.UpdatePluginSettings(pluginPackage.path, pluginPackage.settings);
+            PluginSettingsHelper.mergePluginSettings(pluginPackage.settingsJson, pluginPackage.settings);
+            PluginManager.UpdatePluginSettings(pluginPackage.path, pluginPackage.settingsJson);
             if (IsPluginEnabled)
             {
                 PluginManager.LoadPlugin(pluginPackage.plugin);

--- a/HunterPie/HunterPie.Plugins/PluginManager.cs
+++ b/HunterPie/HunterPie.Plugins/PluginManager.cs
@@ -102,7 +102,7 @@ namespace HunterPie.Plugins
                         }
                     }
 
-                    PluginSettings modSettings = GetPluginSettings(module);
+                    var modSettings = GetPluginSettingsJson(module);
 
                     if (!string.IsNullOrEmpty(modInformation.EntryPoint) && File.Exists(Path.Combine(module, modInformation.EntryPoint)))
                     {
@@ -126,7 +126,13 @@ namespace HunterPie.Plugins
                     if (entries.Count() > 0)
                     {
                         dynamic mod = plugin.CreateInstance(entries.First().ToString());
-                        packages.Add(new PluginPackage { plugin = mod, information = modInformation, settings = modSettings, path = module });
+                        packages.Add(new PluginPackage {
+                            plugin = mod,
+                            information = modInformation,
+                            settings = PluginSettingsHelper.GetPluginSettings(modSettings),
+                            settingsJson = modSettings,
+                            path = module
+                        });
                     }
                 }
                 catch (Exception err)
@@ -230,26 +236,23 @@ namespace HunterPie.Plugins
 
         }
 
-        internal static PluginSettings GetPluginSettings(string path)
+        internal static JObject GetPluginSettingsJson(string path)
         {
-            PluginSettings settings;
             if (!File.Exists(Path.Combine(path, "plugin.settings.json")))
             {
-                settings = new PluginSettings();
-
-                File.WriteAllText(Path.Combine(path, "plugin.settings.json"),
-                    JsonConvert.SerializeObject(settings, Newtonsoft.Json.Formatting.Indented));
+                var settings = JObject.FromObject(new PluginSettings());
+                UpdatePluginSettings(path, settings);
+                return settings;
             }
             else
             {
-                settings = JsonConvert.DeserializeObject<PluginSettings>(File.ReadAllText(Path.Combine(path, "plugin.settings.json")));
+                return JObject.Parse(File.ReadAllText(Path.Combine(path, "plugin.settings.json")));
             }
-            return settings;
         }
 
-        internal static void UpdatePluginSettings(string path, PluginSettings newSettings)
+        internal static void UpdatePluginSettings(string path, JObject newSettings)
         {
-            File.WriteAllText(Path.Combine(path, "plugin.settings.json"), JsonConvert.SerializeObject(newSettings, Newtonsoft.Json.Formatting.Indented));
+            File.WriteAllText(Path.Combine(path, "plugin.settings.json"), newSettings.ToString());
         }
 
         /// <summary>

--- a/Update/Update.csproj
+++ b/Update/Update.csproj
@@ -106,7 +106,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.2</Version>
+      <Version>12.0.3</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
# Fixed plugin settings get deleted on disable

I tried using _plugin.settings.json_ to put my own settings, but if you disable and enable the plugin, the settings get wiped out. Turns out that HunterPie loads the settings via `JsonConvert.DeserializeObject<PluginSettings>(...)`, but Newtonsoft doesn't honor subtype json... It wouldn't know how.

This works around that by treating the settings are JSON, extracting `PluginSettings` for whatever HunterPie does with it, and before saving, it merges the original JSON with the potentially changed setting(s).

There are tests for the helper class that I added.

## Related issues

In my plugin's repo I have these open:

https://github.com/SupaStuff/MHWItemBoxTracker/issues/13
https://github.com/SupaStuff/MHWItemBoxTracker/issues/14

This change fixes them. Alternatively, I could just write to a different file, but this is better.