### PR TITLE
Fixed some warnings

### DIFF
--- a/HunterPie.Core/Core/Local/Jobs/HuntingHorn.cs
+++ b/HunterPie.Core/Core/Local/Jobs/HuntingHorn.cs
@@ -208,7 +208,7 @@ namespace HunterPie.Core.Jobs
         public delegate void HuntingHornSongEvents(object source, HuntingHornSongEventArgs args);
         public delegate void HuntingHornSongCastEvents(object source, HuntingHornSongCastEventArgs args);
 
-        public event HuntingHornEvents OnSongsListUpdate;
+        // public event HuntingHornEvents OnSongsListUpdate;
         public event HuntingHornEvents OnNoteColorUpdate;
 
         public event HuntingHornNoteEvents OnNoteQueueUpdate;

--- a/HunterPie.UI/GUI/Widgets/MantleTimer.xaml.cs
+++ b/HunterPie.UI/GUI/Widgets/MantleTimer.xaml.cs
@@ -207,7 +207,7 @@ namespace HunterPie.GUI.Widgets
         }));
 
 
-        public void ScaleWidget(double NewScaleX, double NewScaleY)
+        override public void ScaleWidget(double NewScaleX, double NewScaleY)
         {
             if (NewScaleX <= 0.2) return;
             Width = BaseWidth * NewScaleX;


### PR DESCRIPTION
Not that important, but it was in PR #129. It's not all the warnings, though...

Warnings fixed are:

- `warning CS0067: The event 'HuntingHorn.OnSongsListUpdate' is never used`
- `warning CS0114: 'MantleTimer.ScaleWidget(double, double)' hides inherited member 'Widget.ScaleWidget(double, double)'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword.`

Warnings not fixed are:
- `warning MSB3277: Found conflicts between different versions of "Newtonsoft.Json" that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.`
- `warning MSB3270: There was a mismatch between the processor architecture of the project being built "MSIL" and the processor architecture of the reference "~\code\HunterPie\HunterPie.Core\bin\Release\HunterPie.Core.dll", "AMD64". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.`

idk what those 2 are about. It's just noise...