### PR TITLE
custom controls bindings fix

### DIFF
--- a/HunterPie.UI/GUIControls/Custom Controls/MinimalSlider.xaml
+++ b/HunterPie.UI/GUIControls/Custom Controls/MinimalSlider.xaml
@@ -14,7 +14,7 @@
                  TextChanged="TextBoxBase_OnTextChanged"
                  LostFocus="TextBox_OnLostFocus"
                  />
-        <Slider Value="{Binding Value, ElementName=SliderControl, Mode=TwoWay}"
+        <Slider Value="{Binding Value, ElementName=SliderControl, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 Maximum="{Binding Path=MaxValue, ElementName=SliderControl, Mode=OneWay}"
                 Minimum="{Binding Path=MinValue, ElementName=SliderControl, Mode=OneWay}"
                 TickFrequency="{Binding Path=MinChange, ElementName=SliderControl, Mode=OneWay}"

--- a/HunterPie.UI/GUIControls/Custom Controls/TextInput.xaml
+++ b/HunterPie.UI/GUIControls/Custom Controls/TextInput.xaml
@@ -1,22 +1,21 @@
 ﻿<UserControl x:Class="HunterPie.GUIControls.Custom_Controls.TextInput"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              x:Name="TextInputCtrl"
              mc:Ignorable="d"
-             DataContext="{Binding RelativeSource={RelativeSource Self}}"
              Height="30"  Margin="10,0,10,5">
     <DockPanel>
-        <TextBlock Text="{Binding Label}" Foreground="WhiteSmoke" DockPanel.Dock="Left" FontFamily="Segoe UI Light" Padding="0,0,10,0"
+        <TextBlock Text="{Binding Label, ElementName=TextInputCtrl}" Foreground="WhiteSmoke" DockPanel.Dock="Left" FontFamily="Segoe UI Light" Padding="0,0,10,0"
                    VerticalAlignment="Center"/>
         <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch" DockPanel.Dock="Right">
-            <TextBox x:Name="TextBox"  Text="{Binding Text, UpdateSourceTrigger=PropertyChanged}" 
+            <TextBox x:Name="TextBox"  Text="{Binding Text, ElementName=TextInputCtrl, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
                      Background="{x:Null}" Foreground="#ffbfbfbf" BorderBrush="#FFABADB3"
                      IsReadOnly="{Binding IsReadOnly, ElementName=TextInputCtrl}"
                      BorderThickness="0,0,0,1" HorizontalContentAlignment="Center"
                      VerticalContentAlignment="Center" />
-            <TextBox x:Name="WatermarkTextBox" IsHitTestVisible="False" IsReadOnly="True" Foreground="#cc9E9D9D" Text="{Binding Watermark}"
+            <TextBox x:Name="WatermarkTextBox" IsHitTestVisible="False" IsReadOnly="True" Foreground="#cc9E9D9D" Text="{Binding Watermark, ElementName=TextInputCtr}"
                      Background="{x:Null}"
                      VerticalContentAlignment="Center"
                      HorizontalContentAlignment="Center"


### PR DESCRIPTION
Without these changes, it would be impossible to correctly bind to value properties of custom controls. These should probably be working since plugins can use them for settings now.