### PR TITLE
added LoadJson and SaveJson to PluginExtension

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Before moving these methods here, I made them extension methods for Main:
https://github.com/Stuff-Mods/MHWItemBoxTracker/blob/settings/ItemBoxTracker/MainExtension.cs

The compiler complains that await can only be used in an async function... So I get around it like this:

https://github.com/Stuff-Mods/MHWItemBoxTracker/blob/e5859683a1d85d14a904ee5068e55dc3425f7efb/ItemBoxTracker/Main.cs#L32-L36
```cs
            Dispatch(async () => {
                var module = await this.LoadJson<PluginInformation>("module.json");
                Name = module.Name;
                Description = module.Description;
            });
```

https://github.com/Stuff-Mods/MHWItemBoxTracker/blob/e5859683a1d85d14a904ee5068e55dc3425f7efb/ItemBoxTracker/GUI/ItemBoxTracker.xaml.cs#L26-L32
```cs
            Dispatch(async () => {
                widgetSettings = await Plugin.LoadJson<ItemBoxWidgetSettings>(settingsJson);
                Plugin.Log($"Loaded widget settings...{JsonConvert.SerializeObject(widgetSettings)}");
                Plugin.Log($"Settings: {JsonConvert.SerializeObject(Settings)}");

                ApplySettings();
            })
```

Here's some logs I put around save and load for widget settings:
![image](https://user-images.githubusercontent.com/5027713/113965655-cb665980-97fb-11eb-92da-b3be74a79fa0.png)
